### PR TITLE
Avoid using codeql-action to initialise codeql

### DIFF
--- a/.github/workflows/codeql-query.yml
+++ b/.github/workflows/codeql-query.yml
@@ -63,16 +63,20 @@ jobs:
           }
           console.log(`::set-output name=repositories::${JSON.stringify(repositories)}`);
 
-      # This might not be the cleanest way to get hold of CodeQL but it's reliable
-      # and widely used. The ugly part is that is initialises a database of the
-      # given language that we just ignore.
+      # NOTE: this is only expected to work on github.com hosted runnners.
+      # It will not work on any self-hosted runners.
       - name: Initialize CodeQL
         id: init
-        uses: github/codeql-action/init@v1
-        with:
-          languages: ${{ github.event.inputs.language }}
-        env:
-          CODEQL_ENABLE_EXPERIMENTAL_FEATURES: true
+        run: |
+          # Take the most modern version
+          VERSION="$(find "${{ runner.tool_cache }}/CodeQL/" -maxdepth 1 -mindepth 1 -type d -print0 \
+                      | sort --zero-terminated \
+                      | tail --zero-terminated --lines 1 \
+                      | tr -d '\0')"
+
+          CODEQL="$VERSION/x64/codeql/codeql"
+          "${CODEQL}" version --format=json
+          echo "::set-output name=codeql-path::${CODEQL}"
 
       - name: Run query
         uses: github/codeql-variant-analysis-action/query@main
@@ -89,13 +93,20 @@ jobs:
       - run
 
     steps:
+      # NOTE: this is only expected to work on github.com hosted runnners.
+      # It will not work on any self-hosted runners.
       - name: Initialize CodeQL
         id: init
-        uses: github/codeql-action/init@v1
-        with:
-          languages: ${{ github.event.inputs.language }}
-        env:
-          CODEQL_ENABLE_EXPERIMENTAL_FEATURES: true
+        run: |
+          # Take the most modern version
+          VERSION="$(find "${{ runner.tool_cache }}/CodeQL/" -maxdepth 1 -mindepth 1 -type d -print0 \
+                      | sort --zero-terminated \
+                      | tail --zero-terminated --lines 1 \
+                      | tr -d '\0')"
+
+          CODEQL="$VERSION/x64/codeql/codeql"
+          "${CODEQL}" version --format=json
+          echo "::set-output name=codeql-path::${CODEQL}"
 
       - name: Combine results
         uses: github/codeql-variant-analysis-action/combine-results@main


### PR DESCRIPTION
Swap out the call to `codeql-action/init` for just using the CodeQL bundle built in to the actions images. It's known that this won't work on self-hosted runners, but that's a concern for the future and we're happy to just deal with it later.

This should theoretically be all that's needed to use a controller repository that doesn't have GHAS enabled.