### PR TITLE
Add permissions blocks to workflow jobs

### DIFF
--- a/.github/workflows/codeql-query.yml
+++ b/.github/workflows/codeql-query.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       repoNwoChunks: ${{ steps.split.outputs.repoNwoChunks }}
+    permissions: {}
 
     steps:
       - name: Mask download URL
@@ -32,6 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         repoNwos: ${{ fromJSON(needs.setup.outputs.repoNwoChunks) }}
+    permissions: {}
 
     steps:
       - name: Mask download URL
@@ -91,6 +93,8 @@ jobs:
     if: always()
     needs:
       - run
+    permissions:
+      issues: write
 
     steps:
       # NOTE: this is only expected to work on github.com hosted runnners.


### PR DESCRIPTION
We can limit the scopes that the actions token has, rather than giving it full write permissions to the `github/codeql-variant-analysis-action` repository. I think that the only job that needs any permissions at all is when we create the issue at the end. The proof will be in testing it though.