### PR TITLE
Add a label to PRs once tests have passed once

### DIFF
--- a/.github/workflows/codeql-query.yml
+++ b/.github/workflows/codeql-query.yml
@@ -81,7 +81,7 @@ jobs:
           echo "::set-output name=codeql-path::${CODEQL}"
 
       - name: Run query
-        uses: github/codeql-variant-analysis-action/query@main
+        uses: github/codeql-variant-analysis-action/query@robertbrignull/tests_label
         with:
           query_pack_url: ${{ github.event.inputs.query_pack_url }}
           language: ${{ github.event.inputs.language }}
@@ -112,7 +112,7 @@ jobs:
           echo "::set-output name=codeql-path::${CODEQL}"
 
       - name: Combine results
-        uses: github/codeql-variant-analysis-action/combine-results@main
+        uses: github/codeql-variant-analysis-action/combine-results@robertbrignull/tests_label
         with:
           query_pack_url: ${{ github.event.inputs.query_pack_url }}
           language: ${{ github.event.inputs.language }}

--- a/.github/workflows/codeql-query.yml
+++ b/.github/workflows/codeql-query.yml
@@ -81,7 +81,7 @@ jobs:
           echo "::set-output name=codeql-path::${CODEQL}"
 
       - name: Run query
-        uses: github/codeql-variant-analysis-action/query@robertbrignull/tests_label
+        uses: github/codeql-variant-analysis-action/query@main
         with:
           query_pack_url: ${{ github.event.inputs.query_pack_url }}
           language: ${{ github.event.inputs.language }}
@@ -112,7 +112,7 @@ jobs:
           echo "::set-output name=codeql-path::${CODEQL}"
 
       - name: Combine results
-        uses: github/codeql-variant-analysis-action/combine-results@robertbrignull/tests_label
+        uses: github/codeql-variant-analysis-action/combine-results@main
         with:
           query_pack_url: ${{ github.event.inputs.query_pack_url }}
           language: ${{ github.event.inputs.language }}

--- a/.github/workflows/integration-test-call.yml
+++ b/.github/workflows/integration-test-call.yml
@@ -47,7 +47,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
 
       - name: Add success label to pull request
-        if: ${{ needs.query.result == 'success' && github.event.inputs.pr_number != "" }}
+        if: ${{ needs.query.result == 'success' && github.event.inputs.pr_number != '' }}
         run: |
           gh api -X POST "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.inputs.pr_number }}/labels" \
             -d '{"labels":["integration tests succeeded"]}'

--- a/.github/workflows/integration-test-call.yml
+++ b/.github/workflows/integration-test-call.yml
@@ -53,8 +53,6 @@ jobs:
         if: ${{ needs.query.result == 'success' && github.event.inputs.pr_number != '' }}
         run: |
           gh pr edit "${{ github.event.inputs.pr_number }}" --add-label "integration tests succeeded"
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
 
       - name: Update status check to state 'failure'
         if: ${{ needs.query.result != 'success' }}

--- a/.github/workflows/integration-test-call.yml
+++ b/.github/workflows/integration-test-call.yml
@@ -35,6 +35,9 @@ jobs:
     needs:
       - query
     steps:
+      # Need to check out repo so that 'gh pr' will know the correct repo
+      - uses: actions/checkout@v2
+
       - name: Update status check to state 'success'
         if: ${{ needs.query.result == 'success' }}
         run: |
@@ -52,8 +55,6 @@ jobs:
           gh pr edit "${{ github.event.inputs.pr_number }}" --add-label "integration tests succeeded"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
-          REPO: ${{ github.event.repository.name }}
 
       - name: Update status check to state 'failure'
         if: ${{ needs.query.result != 'success' }}

--- a/.github/workflows/integration-test-call.yml
+++ b/.github/workflows/integration-test-call.yml
@@ -25,7 +25,7 @@ jobs:
   query:
     needs:
       - init
-    uses: github/codeql-variant-analysis-action/.github/workflows/codeql-query.yml@main
+    uses: github/codeql-variant-analysis-action/.github/workflows/codeql-query.yml@robertbrignull/tests_label
     secrets:
       TEST_PAT: ${{ secrets.BOT_TOKEN }}
 

--- a/.github/workflows/integration-test-call.yml
+++ b/.github/workflows/integration-test-call.yml
@@ -49,8 +49,7 @@ jobs:
       - name: Add success label to pull request
         if: ${{ needs.query.result == 'success' && github.event.inputs.pr_number != '' }}
         run: |
-          gh api -X POST "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.inputs.pr_number }}/labels" \
-            -f body='{"labels":["integration tests succeeded"]}'
+          gh pr edit "${{ github.event.inputs.pr_number }}" --add-label "integration tests succeeded"
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
 

--- a/.github/workflows/integration-test-call.yml
+++ b/.github/workflows/integration-test-call.yml
@@ -25,7 +25,7 @@ jobs:
   query:
     needs:
       - init
-    uses: github/codeql-variant-analysis-action/.github/workflows/codeql-query.yml@robertbrignull/tests_label
+    uses: github/codeql-variant-analysis-action/.github/workflows/codeql-query.yml@main
     secrets:
       TEST_PAT: ${{ secrets.BOT_TOKEN }}
 

--- a/.github/workflows/integration-test-call.yml
+++ b/.github/workflows/integration-test-call.yml
@@ -50,7 +50,7 @@ jobs:
         if: ${{ needs.query.result == 'success' && github.event.inputs.pr_number != '' }}
         run: |
           gh api -X POST "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.inputs.pr_number }}/labels" \
-            -d '{"labels":["integration tests succeeded"]}'
+            -f body='{"labels":["integration tests succeeded"]}'
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
 

--- a/.github/workflows/integration-test-call.yml
+++ b/.github/workflows/integration-test-call.yml
@@ -6,6 +6,7 @@ on:
       query_pack_url:
       language:
       instructions_url:
+      pr_number:
 
 jobs:
   init:
@@ -42,6 +43,14 @@ jobs:
             -f state=success \
             -f description="integration-test-call.yml" \
             -f target_url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+
+      - name: Add success label to pull request
+        if: ${{ needs.query.result == 'success' && github.event.inputs.pr_number != "" }}
+        run: |
+          gh api -X POST "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.inputs.pr_number }}/labels" \
+            -d '{"labels":["integration tests succeeded"]}'
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
 

--- a/.github/workflows/integration-test-call.yml
+++ b/.github/workflows/integration-test-call.yml
@@ -36,7 +36,7 @@ jobs:
       - query
     steps:
       # Need to check out repo so that 'gh pr' will know the correct repo
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Update status check to state 'success'
         if: ${{ needs.query.result == 'success' }}

--- a/.github/workflows/integration-test-call.yml
+++ b/.github/workflows/integration-test-call.yml
@@ -35,6 +35,9 @@ jobs:
     needs:
       - query
     steps:
+      # Need to check out repo so that 'gh pr' will know the correct repo
+      - uses: actions/checkout@v2
+
       - name: Update status check to state 'success'
         if: ${{ needs.query.result == 'success' }}
         run: |

--- a/.github/workflows/integration-test-call.yml
+++ b/.github/workflows/integration-test-call.yml
@@ -52,9 +52,10 @@ jobs:
       - name: Add success label to pull request
         if: ${{ needs.query.result == 'success' && github.event.inputs.pr_number != '' }}
         run: |
-          gh pr edit "${{ github.event.inputs.pr_number }}" --add-label "integration tests succeeded"
+          gh pr edit "$PR_NUM" --add-label "integration tests succeeded"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.inputs.pr_number }}
 
       - name: Update status check to state 'failure'
         if: ${{ needs.query.result != 'success' }}

--- a/.github/workflows/integration-test-call.yml
+++ b/.github/workflows/integration-test-call.yml
@@ -35,9 +35,6 @@ jobs:
     needs:
       - query
     steps:
-      # Need to check out repo so that 'gh pr' will know the correct repo
-      - uses: actions/checkout@v2
-
       - name: Update status check to state 'success'
         if: ${{ needs.query.result == 'success' }}
         run: |
@@ -53,6 +50,10 @@ jobs:
         if: ${{ needs.query.result == 'success' && github.event.inputs.pr_number != '' }}
         run: |
           gh pr edit "${{ github.event.inputs.pr_number }}" --add-label "integration tests succeeded"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
 
       - name: Update status check to state 'failure'
         if: ${{ needs.query.result != 'success' }}

--- a/.github/workflows/integration-test-trigger.yml
+++ b/.github/workflows/integration-test-trigger.yml
@@ -23,9 +23,14 @@ jobs:
       # The owner of the provided token must have write access to trigger this workflow run.
       - name: Trigger the real workflow
         run: |
+          if [ ${{ github.event_name }} == "pull_request" ]; then
+            REF="${{ github.event.pull_request.head.ref }}"
+          else
+            REF="$GITHUB_REF"
+          fi
           gh workflow run integration-test-call.yml \
             -R "$GITHUB_REPOSITORY" \
-            -r "$GITHUB_REF" \
+            -r "$REF" \
             -f language=go \
             -f query_pack_url="https://github.com/$GITHUB_REPOSITORY/releases/download/test/test_pack2.tar.gz" \
             -f instructions_url="https://github.com/$GITHUB_REPOSITORY/releases/download/test/instructions.json" \

--- a/.github/workflows/integration-test-trigger.yml
+++ b/.github/workflows/integration-test-trigger.yml
@@ -23,8 +23,8 @@ jobs:
       # The owner of the provided token must have write access to trigger this workflow run.
       - name: Trigger the real workflow
         run: |
-          if [ ${{ github.event_name }} == "pull_request" ]; then
-            REF="${{ github.event.pull_request.head.ref }}"
+          if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+            REF="$GITHUB_HEAD_REF"
           else
             REF="$GITHUB_REF"
           fi

--- a/.github/workflows/integration-test-trigger.yml
+++ b/.github/workflows/integration-test-trigger.yml
@@ -2,6 +2,8 @@ name: "Integration test (trigger only)"
 
 on:
   push:
+    branches: [main]
+  pull_request:
 
 jobs:
   trigger:
@@ -26,6 +28,7 @@ jobs:
             -r "$GITHUB_REF" \
             -f language=go \
             -f query_pack_url="https://github.com/$GITHUB_REPOSITORY/releases/download/test/test_pack2.tar.gz" \
-            -f instructions_url="https://github.com/$GITHUB_REPOSITORY/releases/download/test/instructions.json"
+            -f instructions_url="https://github.com/$GITHUB_REPOSITORY/releases/download/test/instructions.json" \
+            -f pr_number="${{ github.event.pull_request.number }}"
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Check label is present on PR
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ "$GITHUB_EVENT_NAME" == 'pull_request' }}
         run: |
           gh api "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.pull_request.number }}/labels" | jq -r '.[].name' | grep "integration tests succeeded"
         env:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Check label is present on PR
-        if: ${{ "$GITHUB_EVENT_NAME" == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           gh api "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.pull_request.number }}/labels" | jq -r '.[].name' | grep "integration tests succeeded"
         env:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,6 +15,17 @@ jobs:
       - name: Check workflow references only main
         run: |
           ! grep 'uses: github/codeql-variant-analysis-action/' .github/workflows/codeql-query.yml | grep -q -v '@main$'
+  
+  integration-tests-have-been-run:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check label is present on PR
+        if: ${{ github.event_name == "pull_request" }} 
+        run: |
+          gh api "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.inputs.pr_number }}/labels" | jq -r '.[].name' | grep "integration tests succeeded"
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
 
   lint-js:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,17 +15,17 @@ jobs:
       - name: Check workflow references only main
         run: |
           ! grep 'uses: github/codeql-variant-analysis-action/' .github/workflows/codeql-query.yml | grep -q -v '@main$'
-  
+
   integration-tests-have-been-run:
     runs-on: ubuntu-latest
 
     steps:
       - name: Check label is present on PR
-        if: ${{ github.event_name == 'pull_request' }} 
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
-          gh api "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.inputs.pr_number }}/labels" | jq -r '.[].name' | grep "integration tests succeeded"
+          gh api "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.pull_request.number }}/labels" | jq -r '.[].name' | grep "integration tests succeeded"
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   lint-js:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Check label is present on PR
-        if: ${{ github.event_name == "pull_request" }} 
+        if: ${{ github.event_name == 'pull_request' }} 
         run: |
           gh api "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.inputs.pr_number }}/labels" | jq -r '.[].name' | grep "integration tests succeeded"
         env:


### PR DESCRIPTION
This is an idea to reduce the chance of forgetting to run the integration tests. It's not perfect but hopefully it'll do enough to make us not forget.

The idea is that you're most likely to just forget to run the tests at all. Once you've done it once by updating the action branch and running the tests you're more likely to remember to run them again if you make any big changes to the PR. Therefore once the tests have run once with the correct action branch it adds a label to the PR. Then there's another CI check that checks for the presence of the label.

It's worth noting that this approach isn't perfect. It won't make you run the tests again if you make any changes. There are other approaches we could take to solve the problem of it being tedious to run the tests and easy to forget. This is just one approach and a fairly simple one. I think it's worth trying this since it's quite low effort, rather than putting lots of effort into doing something more full featured 🤷 