### PR TITLE
Adjustments to integration tests label check

### DIFF
--- a/.github/workflows/integration-test-call.yml
+++ b/.github/workflows/integration-test-call.yml
@@ -60,7 +60,6 @@ jobs:
             gh pr edit "$PR_NUM" --add-label "integration tests succeeded"
           else
             echo "Detected $NUM_USAGES references to $REF branch"
-            exit 1
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-test-call.yml
+++ b/.github/workflows/integration-test-call.yml
@@ -52,7 +52,16 @@ jobs:
       - name: Add success label to pull request
         if: ${{ needs.query.result == 'success' && github.event.inputs.pr_number != '' }}
         run: |
-          gh pr edit "$PR_NUM" --add-label "integration tests succeeded"
+          # Get the branch without refs/heads/
+          REF=$(git rev-parse --abbrev-ref HEAD)
+          # Only add the label if the workflow references the correct branch
+          NUM_USAGES=$(grep 'uses: github/codeql-variant-analysis-action/' .github/workflows/codeql-query.yml | grep "@${REF}$" | wc -l)
+          if [ "$NUM_USAGES" == 2 ]; then
+            gh pr edit "$PR_NUM" --add-label "integration tests succeeded"
+          else
+            echo "Detected $NUM_USAGES references to $REF branch"
+            exit 1
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ github.event.inputs.pr_number }}

--- a/.github/workflows/integration-test-call.yml
+++ b/.github/workflows/integration-test-call.yml
@@ -53,9 +53,9 @@ jobs:
         if: ${{ needs.query.result == 'success' && github.event.inputs.pr_number != '' }}
         run: |
           # Get the branch without refs/heads/
-          REF=$(git rev-parse --abbrev-ref HEAD)
+          REF="$(git rev-parse --abbrev-ref HEAD)"
           # Only add the label if the workflow references the correct branch
-          NUM_USAGES=$(grep 'uses: github/codeql-variant-analysis-action/' .github/workflows/codeql-query.yml | grep "@${REF}$" | wc -l)
+          NUM_USAGES="$(grep 'uses: github/codeql-variant-analysis-action/' .github/workflows/codeql-query.yml | grep "@${REF}$" | wc -l)"
           if [ "$NUM_USAGES" == 2 ]; then
             gh pr edit "$PR_NUM" --add-label "integration tests succeeded"
           else

--- a/.github/workflows/integration-tests-label.yml
+++ b/.github/workflows/integration-tests-label.yml
@@ -1,0 +1,15 @@
+name: "Integration tests label check"
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+
+jobs:
+  integration-tests-have-been-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check label is present on PR
+        run: |
+          gh api "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.pull_request.number }}/labels" | jq -r '.[].name' | grep "integration tests succeeded"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,17 +16,6 @@ jobs:
         run: |
           ! grep 'uses: github/codeql-variant-analysis-action/' .github/workflows/codeql-query.yml | grep -q -v '@main$'
 
-  integration-tests-have-been-run:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check label is present on PR
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          gh api "/repos/$GITHUB_REPOSITORY/issues/${{ github.event.pull_request.number }}/labels" | jq -r '.[].name' | grep "integration tests succeeded"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   lint-js:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Hopefully fixed the problems from https://github.com/github/codeql-variant-analysis-action/pull/720

The `integration-tests-have-been-run` check now runs when a label is added to the PR so it'll update its state.

The "Add success label to pull request" step now only adds the label if the workflow references the current branch.