### PR TITLE
Update check-node-modules.sh to mention running on linux

### DIFF
--- a/.github/workflows/script/check-node-modules.sh
+++ b/.github/workflows/script/check-node-modules.sh
@@ -15,6 +15,7 @@ npm run removeNPMAbsolutePaths
 if [ ! -z "$(git status --porcelain)" ]; then
     # If we get a fail here then the PR needs attention
     >&2 echo "Failed: node_modules are not up to date. Run 'npm ci && npm run removeNPMAbsolutePaths'."
+    >&2 echo "For best results use linux when running the above commands. Use a codespace or docker container if necessary."
     git status
     exit 1
 fi


### PR DESCRIPTION
What do people think of this? Is this enough of a warning to help us remember how to do things?

I'm also not actually sure if linux is strictly needed as windows might work too. All I know currently is that mac doesn't work.