### PR TITLE
Clean-up: Delete unused inputs from `combine-results`

### DIFF
--- a/.github/workflows/codeql-query.yml
+++ b/.github/workflows/codeql-query.yml
@@ -81,7 +81,7 @@ jobs:
           echo "::set-output name=codeql-path::${CODEQL}"
 
       - name: Run query
-        uses: github/codeql-variant-analysis-action/query@tidy-inputs
+        uses: github/codeql-variant-analysis-action/query@main
         with:
           query_pack_url: ${{ github.event.inputs.query_pack_url }}
           language: ${{ github.event.inputs.language }}
@@ -112,4 +112,4 @@ jobs:
           echo "::set-output name=codeql-path::${CODEQL}"
 
       - name: Combine results
-        uses: github/codeql-variant-analysis-action/combine-results@tidy-inputs
+        uses: github/codeql-variant-analysis-action/combine-results@main

--- a/.github/workflows/integration-test-call.yml
+++ b/.github/workflows/integration-test-call.yml
@@ -25,7 +25,7 @@ jobs:
   query:
     needs:
       - init
-    uses: github/codeql-variant-analysis-action/.github/workflows/codeql-query.yml@tidy-inputs
+    uses: github/codeql-variant-analysis-action/.github/workflows/codeql-query.yml@main
     secrets:
       TEST_PAT: ${{ secrets.BOT_TOKEN }}
 


### PR DESCRIPTION
Since https://github.com/github/codeql-variant-analysis-action/pull/703, `combine-results` no longer uploads an issue. That PR removed any dependence on the action inputs, so I think we can remove them 💥 