### PR TITLE
Skip combine-results step if we have a variant analysis ID

### DIFF
--- a/.github/workflows/codeql-query.yml
+++ b/.github/workflows/codeql-query.yml
@@ -96,7 +96,7 @@ jobs:
 
   combine-results:
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ always() && github.event.inputs.variant_analysis_id == '' }}
     needs:
       - run
     permissions: {}

--- a/.github/workflows/codeql-query.yml
+++ b/.github/workflows/codeql-query.yml
@@ -96,7 +96,7 @@ jobs:
 
   combine-results:
     runs-on: ubuntu-latest
-    if: ${{ always() && github.event.inputs.variant_analysis_id == '' }}
+    if: always() && github.event.inputs.variant_analysis_id == ''
     needs:
       - run
     permissions: {}


### PR DESCRIPTION
When in live-results mode, we don't upload actions artifacts, but the `combine-results` job fails if there are no artifacts. But we don't actually need to run the `combine-results` job at all now, so it's purpose is now handled by the github API.

I think doing `always()` and another condition is valid syntax here. Weirdly it would have different behaviour to just the condition on it's own, because actions adds an implicit `if: success()` unless you use `always()` or `failure()`. See https://stackoverflow.com/questions/58858429 and https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions for more info.

We / I should ideally do some tests of this too and make sure it does behave as expected. If we can't get this condition to work, we could also just put the check in code at the start of `combine-results.ts`, but that's not ideal because then we'd start a whole actions runner just to exit immediately.