### PR TITLE
Use `pull_request_target` event for triggering the integration test

### DIFF
--- a/.github/workflows/integration-test-trigger.yml
+++ b/.github/workflows/integration-test-trigger.yml
@@ -3,7 +3,11 @@ name: "Integration test (trigger only)"
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
+
+permissions:
+  actions: write
+  statuses: write
 
 jobs:
   trigger:
@@ -23,7 +27,7 @@ jobs:
       # The owner of the provided token must have write access to trigger this workflow run.
       - name: Trigger the real workflow
         run: |
-          if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+          if [ "$GITHUB_EVENT_NAME" == "pull_request_target" ]; then
             REF="$GITHUB_HEAD_REF"
           else
             REF="$GITHUB_REF"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,7 +3,7 @@ name: "Integration tests"
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
 
 jobs:
   integration-tests:


### PR DESCRIPTION
The integration test is not being triggered for e.g. dependabot PRs. This changes the event to use `pull_request_target` to ensure that we have access to creating a status and triggering the workflow.

I'm not 100% sure about the implications of this, as it will change the security model of the integration test. However, it should only be possible to trigger this when you already have write access or when you have explicitly been approved (since the fork PR workflow permission is set to "Require approval for all outside collaborators").