### PR TITLE
Replace deprecated `set-output` syntax with `GITHUB_OUTPUT`

### DIFF
--- a/.github/workflows/codeql-query.yml
+++ b/.github/workflows/codeql-query.yml
@@ -67,16 +67,16 @@ jobs:
         run: |
           const fs = require('fs');
           const process = require('process');
+
           const allRepos = JSON.parse(fs.readFileSync("instructions.json")).repositories;
           const repoNwos = new Set(${{ toJSON(matrix.repoNwos) }});
           const repositories = allRepos.filter(r => repoNwos.has(r.nwo));
           if ("${{ secrets.TEST_PAT }}") {
             allRepos.forEach(r => r.pat = "${{ secrets.TEST_PAT }}")
           }
+
           const githubOutput = process.env.GITHUB_OUTPUT;
-          const outputFile = fs.openSync(githubOutput, 'a');
-          fs.writeSync(outputFile, `repositories=${JSON.stringify(repositories)}`);
-          fs.closeSync(outputFile);
+          fs.appendFileSync(githubOutput, `repositories=${JSON.stringify(repositories)}`);
 
       # NOTE: this is only expected to work on github.com hosted runnners.
       # It will not work on any self-hosted runners.

--- a/.github/workflows/codeql-query.yml
+++ b/.github/workflows/codeql-query.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout codeql-variant-analysis-action repository
         uses: actions/checkout@v3
         with:
-          repository: 'github/codeql-variant-analysis-action'
+          repository: "github/codeql-variant-analysis-action"
           ref: ${{ github.event.inputs.action_repo_ref }}
 
       - name: Mask download URL
@@ -113,7 +113,7 @@ jobs:
       - name: Checkout codeql-variant-analysis-action repository
         uses: actions/checkout@v3
         with:
-          repository: 'github/codeql-variant-analysis-action'
+          repository: "github/codeql-variant-analysis-action"
           ref: ${{ github.event.inputs.action_repo_ref }}
 
       # NOTE: this is only expected to work on github.com hosted runnners.

--- a/.github/workflows/codeql-query.yml
+++ b/.github/workflows/codeql-query.yml
@@ -22,7 +22,7 @@ jobs:
         id: split
         run: |
           curl --fail --show-error --location --retry 10 "$(jq --raw-output .inputs.instructions_url "$GITHUB_EVENT_PATH")" | \
-            jq --raw-output '"::set-output name=repoNwoChunks::\(.repoNwoChunks)"'
+            jq --raw-output '"repoNwoChunks=\(.repoNwoChunks)" >> $GITHUB_OUTPUT'
 
   run:
     runs-on: ubuntu-latest
@@ -72,7 +72,7 @@ jobs:
           if ("${{ secrets.TEST_PAT }}") {
             allRepos.forEach(r => r.pat = "${{ secrets.TEST_PAT }}")
           }
-          console.log(`::set-output name=repositories::${JSON.stringify(repositories)}`);
+          console.log(`repositories=${JSON.stringify(repositories)} >> $GITHUB_OUTPUT`);
 
       # NOTE: this is only expected to work on github.com hosted runnners.
       # It will not work on any self-hosted runners.
@@ -87,7 +87,7 @@ jobs:
 
           CODEQL="$VERSION/x64/codeql/codeql"
           "${CODEQL}" version --format=json
-          echo "::set-output name=codeql-path::${CODEQL}"
+          echo "codeql-path=${CODEQL}" >> $GITHUB_OUTPUT
 
       - name: Run query
         uses: ./query
@@ -129,7 +129,7 @@ jobs:
 
           CODEQL="$VERSION/x64/codeql/codeql"
           "${CODEQL}" version --format=json
-          echo "::set-output name=codeql-path::${CODEQL}"
+          echo "codeql-path=${CODEQL}" >> $GITHUB_OUTPUT
 
       - name: Combine results
         uses: ./combine-results

--- a/.github/workflows/codeql-query.yml
+++ b/.github/workflows/codeql-query.yml
@@ -22,7 +22,7 @@ jobs:
         id: split
         run: |
           curl --fail --show-error --location --retry 10 "$(jq --raw-output .inputs.instructions_url "$GITHUB_EVENT_PATH")" | \
-            jq --raw-output '"repoNwoChunks=\(.repoNwoChunks)" >> $GITHUB_OUTPUT'
+            jq --raw-output '"repoNwoChunks=\(.repoNwoChunks)"' >> $GITHUB_OUTPUT
 
   run:
     runs-on: ubuntu-latest
@@ -66,13 +66,17 @@ jobs:
         shell: node {0}
         run: |
           const fs = require('fs');
+          const process = require('process');
           const allRepos = JSON.parse(fs.readFileSync("instructions.json")).repositories;
           const repoNwos = new Set(${{ toJSON(matrix.repoNwos) }});
           const repositories = allRepos.filter(r => repoNwos.has(r.nwo));
           if ("${{ secrets.TEST_PAT }}") {
             allRepos.forEach(r => r.pat = "${{ secrets.TEST_PAT }}")
           }
-          console.log(`repositories=${JSON.stringify(repositories)} >> $GITHUB_OUTPUT`);
+          const githubOutput = process.env.GITHUB_OUTPUT;
+          const outputFile = fs.openSync(githubOutput, 'a');
+          fs.writeSync(outputFile, `repositories=${JSON.stringify(repositories)}`);
+          fs.closeSync(outputFile);
 
       # NOTE: this is only expected to work on github.com hosted runnners.
       # It will not work on any self-hosted runners.

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,7 +46,7 @@ jobs:
             exit 1
           fi
 
-          echo "::set-output name=variant_analysis_id::$ID"
+          echo "variant_analysis_id=$ID" >> $GITHUB_OUTPUT
 
       - name: Wait for variant analysis to complete
         run: |


### PR DESCRIPTION
This PR should remove these deprecation warnings:
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

See internal issue too! 😊 