### PR TITLE
Use the correct SHA for status checks in PRs

### DIFF
--- a/.github/workflows/integration-test-trigger.yml
+++ b/.github/workflows/integration-test-trigger.yml
@@ -11,7 +11,12 @@ jobs:
     steps:
       - name: Create a status check in state 'pending'
         run: |
-          gh api -X POST "/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
+          if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+            SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            SHA="$GITHUB_SHA"
+          fi
+          gh api -X POST "/repos/$GITHUB_REPOSITORY/statuses/$SHA" \
             -f context=integration-test \
             -f description="integration-test-call.yml" \
             -f state=pending \


### PR DESCRIPTION
In a PR, we should be using `${{ github.event.pull_request.head.sha }}` to ensure we are creating the status on the commit of the PR, rather than on the automatically created merge commit.

See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request