### PR TITLE
Remove deprecated code

### DIFF
--- a/.github/workflows/codeql-query.yml
+++ b/.github/workflows/codeql-query.yml
@@ -34,7 +34,6 @@ jobs:
       matrix:
         repoNwos: ${{ fromJSON(needs.setup.outputs.repoNwoChunks) }}
     permissions:
-      security-events: write # This permission can be removed soon
       contents: write
 
     steps:

--- a/.github/workflows/codeql-query.yml
+++ b/.github/workflows/codeql-query.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Download and mask tokens
         run: |
           curl --fail --show-error --location --retry 10 --output instructions.json "$(jq --raw-output .inputs.instructions_url "$GITHUB_EVENT_PATH")"
-          jq '.repositories | [.[].token , .[].pat] | map( select( . != null ) ) | .[]' --raw-output instructions.json | \
+          jq '.repositories | .[].pat | select( . != null )' --raw-output instructions.json | \
             xargs -I {} echo "::add-mask::{}"
 
       # Extract the subset of the repositories input that we'll be analysing for this
@@ -185,7 +185,7 @@ jobs:
       - name: Download and mask tokens
         run: |
           curl --fail --show-error --location --retry 10 --output instructions.json "$(jq --raw-output .inputs.instructions_url "$GITHUB_EVENT_PATH")"
-          jq '.repositories | [.[].token , .[].pat] | map( select( . != null ) ) | .[]' --raw-output instructions.json | \
+          jq '.repositories | .[].pat | select( . != null )' --raw-output instructions.json | \
             xargs -I {} echo "::add-mask::{}"
 
       # Extract the repositories that were analyzed in this workflow from the instructions file.
@@ -235,7 +235,7 @@ jobs:
       - name: Download and mask tokens
         run: |
           curl --fail --show-error --location --retry 10 --output instructions.json "$(jq --raw-output .inputs.instructions_url "$GITHUB_EVENT_PATH")"
-          jq '.repositories | [.[].token , .[].pat] | map( select( . != null ) ) | .[]' --raw-output instructions.json | \
+          jq '.repositories | .[].pat | select( . != null )' --raw-output instructions.json | \
             xargs -I {} echo "::add-mask::{}"
 
       - name: Handle workflow cancelled

--- a/query/action.yml
+++ b/query/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: true
 
   repositories:
-    description: "Repositories to run the query against. A JSON encoded array of the form {id: number, nwo: string, token: string}[]"
+    description: "Repositories to run the query against. A JSON encoded array of the form {id: number, nwo: string}[]"
     required: true
 
   codeql:

--- a/update-repo-task-status/action.yml
+++ b/update-repo-task-status/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: true
 
   repositories:
-    description: "Repositories to run the query against. A JSON encoded array of the form {id: number, nwo: string, token: string}[]"
+    description: "Repositories to run the query against. A JSON encoded array of the form {id: number, nwo: string}[]"
     required: true
 
   variant_analysis_id:


### PR DESCRIPTION
🧹 Cleans up code that doesn't get used:

- We no longer need `security-events: write` permission for the MRVA endpoints
- We no longer have a `token` field in the `repositories` object
  - Ideally, we'd also get rid of `pat`, since that only [gets used in old integration tests](https://github.com/github/codeql-variant-analysis-action/blob/2e07ba3fbddcede187f3b53f552c425189b76f83/.github/workflows/codeql-query.yml#L80-L82). We can remove that once live results is fully available.


See internal linked issue for details!