### PR TITLE
Do not allow reruns of the workflow

### DIFF
--- a/.github/workflows/codeql-query.yml
+++ b/.github/workflows/codeql-query.yml
@@ -17,6 +17,11 @@ jobs:
     permissions: {}
 
     steps:
+      - name: Do not allow reruns
+        if: github.run_attempt != 1
+        run: |
+          echo "::error title=Reruns not supported::Multi-repository variant analysis does not support reruns. Please create a new variant analysis to run again."
+          exit 1
       - name: Mask download URL
         run: |
           echo "::add-mask::$(jq .inputs.instructions_url "$GITHUB_EVENT_PATH")"
@@ -40,10 +45,14 @@ jobs:
       contents: write
 
     steps:
+      - name: Do not allow reruns
+        if: github.run_attempt != 1
+        run: |
+          echo "::error title=Reruns not supported::Multi-repository variant analysis does not support reruns. Please create a new variant analysis to run again."
+          exit 1
       # To use the action in this repository, we need to check out the repository
       - name: Checkout codeql-variant-analysis-action repository
         uses: actions/checkout@v3
-        if: always()
         with:
           repository: "github/codeql-variant-analysis-action"
           ref: ${{ github.event.inputs.action_repo_ref }}
@@ -114,7 +123,7 @@ jobs:
           variant_analysis_id: ${{ github.event.inputs.variant_analysis_id }}
 
       - name: Handle workflow failed
-        if: failure() && github.event.inputs.variant_analysis_id != ''
+        if: failure() && github.event.inputs.variant_analysis_id != '' && github.run_attempt == 1
         uses: ./update-repo-task-status
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -132,6 +141,11 @@ jobs:
     permissions: {}
 
     steps:
+      - name: Do not allow reruns
+        if: github.run_attempt != 1
+        run: |
+          echo "::error title=Reruns not supported::Multi-repository variant analysis does not support reruns. Please create a new variant analysis to run again."
+          exit 1
       # To use the action in this repository, we need to check out the repository
       - name: Checkout codeql-variant-analysis-action repository
         uses: actions/checkout@v3
@@ -167,6 +181,11 @@ jobs:
       contents: write
 
     steps:
+      - name: Do not allow reruns
+        if: github.run_attempt != 1
+        run: |
+          echo "::error title=Reruns not supported::Multi-repository variant analysis does not support reruns. Please create a new variant analysis to run again."
+          exit 1
       # To use the action in this repository, we need to check out the repository
       - name: Checkout codeql-variant-analysis-action repository
         uses: actions/checkout@v3
@@ -217,6 +236,11 @@ jobs:
       contents: write
 
     steps:
+      - name: Do not allow reruns
+        if: github.run_attempt != 1
+        run: |
+          echo "::error title=Reruns not supported::Multi-repository variant analysis does not support reruns. Please create a new variant analysis to run again."
+          exit 1
       # To use the action in this repository, we need to check out the repository
       - name: Checkout codeql-variant-analysis-action repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Example run with re-running only failed jobs: https://github.com/github/codeql-variant-analysis-action/actions/runs/3628283507/attempts/2

Example run with re-running setup job: https://github.com/github/codeql-variant-analysis-action/actions/runs/3628283507/attempts/3