### PR TITLE
Use signed auth token

### DIFF
--- a/.github/workflows/codeql-query.yml
+++ b/.github/workflows/codeql-query.yml
@@ -132,6 +132,7 @@ jobs:
           repositories: ${{ steps.repos.outputs.repositories }}
           codeql: ${{ steps.init.outputs.codeql-path }}
           variant_analysis_id: ${{ github.event.inputs.variant_analysis_id }}
+          signed_auth_token: ${{ github.event.inputs.signed_auth_token }}
 
       - name: Handle workflow failed
         if: failure() && github.event.inputs.variant_analysis_id != '' && github.run_attempt == 1
@@ -143,6 +144,7 @@ jobs:
           controller_repo_id: ${{ github.repository_id }}
           repositories: ${{ steps.repos.outputs.repositories }}
           variant_analysis_id: ${{ github.event.inputs.variant_analysis_id }}
+          signed_auth_token: ${{ github.event.inputs.signed_auth_token }}
 
   combine-results:
     runs-on: ubuntu-latest
@@ -236,6 +238,7 @@ jobs:
           controller_repo_id: ${{ github.repository_id }}
           instructions_path: instructions.json
           variant_analysis_id: ${{ github.event.inputs.variant_analysis_id }}
+          signed_auth_token: ${{ github.event.inputs.signed_auth_token }}
 
   update-repo-tasks-statuses-failure:
     runs-on: ubuntu-latest
@@ -285,3 +288,4 @@ jobs:
           controller_repo_id: ${{ github.repository_id }}
           instructions_path: instructions.json
           variant_analysis_id: ${{ github.event.inputs.variant_analysis_id }}
+          signed_auth_token: ${{ github.event.inputs.signed_auth_token }}

--- a/query/action.yml
+++ b/query/action.yml
@@ -27,6 +27,11 @@ inputs:
     # This will eventually be required once live results is fully rolled out
     # required: true
 
+  signed_auth_token:
+    description: "The signed auth token to authenticate against the GitHub API"
+    # This will eventually be required once this is fully rolled out
+    # required: true
+
 runs:
   using: "node16"
   main: "../lib/query.js"

--- a/update-repo-task-status/action.yml
+++ b/update-repo-task-status/action.yml
@@ -18,6 +18,11 @@ inputs:
     description: "The ID of the variant analysis"
     required: true
 
+  signed_auth_token:
+    description: "The signed auth token to authenticate against the GitHub API"
+    # This will eventually be required once this is fully rolled out
+    # required: true
+
 runs:
   using: "node16"
   main: "../lib/update-repo-task-status.js"

--- a/update-repo-task-statuses/action.yml
+++ b/update-repo-task-statuses/action.yml
@@ -18,6 +18,11 @@ inputs:
     description: "The ID of the variant analysis"
     required: true
 
+  signed_auth_token:
+    description: "The signed auth token to authenticate against the GitHub API"
+    # This will eventually be required once this is fully rolled out
+    # required: true
+
 runs:
   using: "node16"
   main: "../lib/update-repo-task-statuses.js"


### PR DESCRIPTION
The signed auth token was not actually being passed into the action because the input was missing. This adds the signed auth token as an input into the appropriate actions. This should have no impact for runs without a signed auth token.