### PR TITLE
Fix CI after node/npm versions have changed

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "codeql-query",
   "version": "1.0.7",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "node_modules/@actions/core": {

--- a/script/generate-json-schemas
+++ b/script/generate-json-schemas
@@ -14,7 +14,7 @@ rm -rf json-schemas-tmp
 mkdir json-schemas-tmp
 
 generate_schema () {
-    $(npm bin)/ts-json-schema-generator \
+    npx ts-json-schema-generator \
       --path $1 \
       --type $2 \
       --out json-schemas-tmp/$2.json \


### PR DESCRIPTION
This PR aims to get the CI working again. I think what's happened is that the version of Node/NPM used on actions runners has increased. We now need to upgrade our lock file in order to get CI to pass again. I'm also hitting issues when generating json schemas.

I generated the package lock change by running `npm ci && npm run removeNPMAbsolutePaths` from a codespace.

The node/npm versions are:
| | codespace | actions |
|---|---|---|
| Node | 19.8.1 | 18.16.0 |
| NPM | 9.5.1 | 9.5.1 |