### PR TITLE
Exclude `dist` from CodeQL analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,2 @@
+paths-ignore:
+  - dist

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
+          config-file: ./.github/codeql/codeql-config.yml
           languages: "javascript"
           queries: security-and-quality
 


### PR DESCRIPTION
The CodeQL analysis is run on the `dist` directory causing a lot of false positives. This excludes the `dist` directory and makes it scan `src` instead.