### PR TITLE
Show repo name when downloading database

### DIFF
--- a/dist/query.js
+++ b/dist/query.js
@@ -62563,7 +62563,7 @@ async function getArtifactContentsForUpload(runQueryResult) {
   });
 }
 async function getDatabase(repo, language) {
-  console.log("Getting database");
+  console.log(`Getting database for ${repo.nwo}`);
   if (repo.downloadUrl) {
     return await download(repo.downloadUrl, `${repo.id}.zip`);
   } else {

--- a/src/query.ts
+++ b/src/query.ts
@@ -164,7 +164,7 @@ async function getArtifactContentsForUpload(
 }
 
 async function getDatabase(repo: Repo, language: string) {
-  console.log("Getting database");
+  console.log(`Getting database for ${repo.nwo}`);
   if (repo.downloadUrl) {
     // Use the provided signed URL to download the database
     return await download(repo.downloadUrl, `${repo.id}.zip`);


### PR DESCRIPTION
When your query gets stuck because it has terrible performance on a specific project, it is much easier to debug when it's possible to see the name of the repository