### PR TITLE
Use original query metadata

### DIFF
--- a/dist/update-repo-task-status.js
+++ b/dist/update-repo-task-status.js
@@ -32134,6 +32134,9 @@ var QueryMetadata_default = {
   definitions: {
     QueryMetadata: {
       properties: {
+        id: {
+          type: "string"
+        },
         kind: {
           type: "string"
         }

--- a/dist/update-repo-task-statuses.js
+++ b/dist/update-repo-task-statuses.js
@@ -32135,6 +32135,9 @@ var QueryMetadata_default = {
   definitions: {
     QueryMetadata: {
       properties: {
+        id: {
+          type: "string"
+        },
         kind: {
           type: "string"
         }

--- a/src/json-schemas/QueryMetadata.json
+++ b/src/json-schemas/QueryMetadata.json
@@ -4,6 +4,9 @@
   "definitions": {
     "QueryMetadata": {
       "properties": {
+        "id": {
+          "type": "string"
+        },
         "kind": {
           "type": "string"
         }


### PR DESCRIPTION
This changes the `codeql bqrs interpret` call to use the original query metadata rather than passing in only a fixed `-t=id=remote-query` argument. This should make MRVA behave more like running a local query since this is [what we also do in the VS Code extension](https://github.com/github/vscode-codeql/blob/31e233cc59c71c664b39d39d40b40f03e13e1737/extensions/ql-vscode/src/codeql-cli/cli.ts#L1057).

We still need to ensure that there is an ID passed in since interpreting a SARIF file requires an ID, so we still have a fallback if we do execute a query without an ID (I'm not sure if that's possible though).