### PR TITLE
Fix support for `codeql-pack.yml` file

### DIFF
--- a/dist/query.js
+++ b/dist/query.js
@@ -62444,9 +62444,13 @@ function getQueryPackName(queryPackPath) {
   const qlpackFile = import_path.default.join(queryPackPath, "qlpack.yml");
   const codeqlpackFile = import_path.default.join(queryPackPath, "codeql-pack.yml");
   let packFile;
-  if (import_fs3.default.statSync(qlpackFile).isFile()) {
+  if (import_fs3.default.statSync(qlpackFile, {
+    throwIfNoEntry: false
+  })?.isFile()) {
     packFile = qlpackFile;
-  } else if (import_fs3.default.statSync(codeqlpackFile).isFile()) {
+  } else if (import_fs3.default.statSync(codeqlpackFile, {
+    throwIfNoEntry: false
+  })?.isFile()) {
     packFile = codeqlpackFile;
   } else {
     throw new Error(`Path '${queryPackPath}' is missing a qlpack file.`);

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -460,9 +460,21 @@ function getQueryPackName(queryPackPath: string) {
   const qlpackFile = path.join(queryPackPath, "qlpack.yml");
   const codeqlpackFile = path.join(queryPackPath, "codeql-pack.yml");
   let packFile: string;
-  if (fs.statSync(qlpackFile).isFile()) {
+  if (
+    fs
+      .statSync(qlpackFile, {
+        throwIfNoEntry: false,
+      })
+      ?.isFile()
+  ) {
     packFile = qlpackFile;
-  } else if (fs.statSync(codeqlpackFile).isFile()) {
+  } else if (
+    fs
+      .statSync(codeqlpackFile, {
+        throwIfNoEntry: false,
+      })
+      ?.isFile()
+  ) {
     packFile = codeqlpackFile;
   } else {
     throw new Error(`Path '${queryPackPath}' is missing a qlpack file.`);


### PR DESCRIPTION
When the `qlpack.yml` file didn't exist, `fs.statSync` would throw an error. Therefore, we would never check if the `codeql-pack.yml` exists.

This fixes it by using the `throwIfNoEntry` option of `fs.statSync`.