### PR TITLE
Use run-name which can accept dynamic expressions

### DIFF
--- a/variant-analysis-workflow.yml
+++ b/variant-analysis-workflow.yml
@@ -1,4 +1,5 @@
 name: CodeQL Variant Analysis
+# `run-name` can contain expressions, and will override the `name` once the workflow starts running
 run-name: ${{ github.event.inputs.workflow_name }}
 
 env:

--- a/variant-analysis-workflow.yml
+++ b/variant-analysis-workflow.yml
@@ -1,4 +1,5 @@
 name: CodeQL Variant Analysis
+run-name: ${{ github.event.inputs.workflow_name }}
 
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: true

--- a/variant-analysis-workflow.yml
+++ b/variant-analysis-workflow.yml
@@ -1,4 +1,4 @@
-name: ${{ github.event.inputs.workflow_name }}
+name: CodeQL Variant Analysis
 
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: true


### PR DESCRIPTION
This fixes MRVA when using the new feature of reading the dynamic workflow directly from this repo. Unfortunately the `name` field cannot use expressions, so workflow runs were failing. Instead we can use `run-name` which does work with expressions.

Currently this feature is only enabled on my private test controller repo, but I have screenshots of a successful run I did using this branch.

<img width="1746" alt="Screenshot 2023-10-25 at 11 21 11" src="https://github.com/github/codeql-variant-analysis-action/assets/3749000/f35c61fc-8d35-4f8d-af60-064b861453f1">
<img width="2383" alt="Screenshot 2023-10-25 at 11 21 21" src="https://github.com/github/codeql-variant-analysis-action/assets/3749000/3cb43012-812f-462f-8910-752db7a5f2f0">
