### PR TITLE
Only upload results if there are any

### DIFF
--- a/dist/query.js
+++ b/dist/query.js
@@ -60316,12 +60316,14 @@ async function run() {
       const dbZip = await getDatabase(repo, language);
       console.log("Running query");
       const runQueryResult = await runQuery(codeql, dbZip, repo.nwo, queryPack);
-      await uploadRepoResult(
-        controllerRepoId,
-        variantAnalysisId,
-        repo,
-        runQueryResult
-      );
+      if (runQueryResult.resultCount > 0) {
+        await uploadRepoResult(
+          controllerRepoId,
+          variantAnalysisId,
+          repo,
+          runQueryResult
+        );
+      }
       await setVariantAnalysisRepoSucceeded(
         controllerRepoId,
         variantAnalysisId,

--- a/src/query.ts
+++ b/src/query.ts
@@ -87,12 +87,15 @@ async function run(): Promise<void> {
       console.log("Running query");
       const runQueryResult = await runQuery(codeql, dbZip, repo.nwo, queryPack);
 
-      await uploadRepoResult(
-        controllerRepoId,
-        variantAnalysisId,
-        repo,
-        runQueryResult,
-      );
+      if (runQueryResult.resultCount > 0) {
+        await uploadRepoResult(
+          controllerRepoId,
+          variantAnalysisId,
+          repo,
+          runQueryResult,
+        );
+      }
+
       await setVariantAnalysisRepoSucceeded(
         controllerRepoId,
         variantAnalysisId,


### PR DESCRIPTION
This is a repeat of https://github.com/github/codeql-variant-analysis-action/pull/853

Only call `uploadRepoResult` if there are results. This function is what makes the `/artifact` API request and uploads the artifact contents to azure. So without it we only do the request that sets the repo task status to "succeeded".

See the corresponding API change that makes it handle repo tasks that are succeeded without an artifact uploaded. This PR should not be merged until the API is updated.