### PR TITLE
Remove unused file size fields from RunQueryResult

### DIFF
--- a/dist/query.js
+++ b/dist/query.js
@@ -74861,7 +74861,6 @@ async function runQuery(codeql, database, nwo, queryPack) {
   );
   let resultCount;
   let sarifFilePath;
-  let sarifFileSize;
   if (sarifOutputType !== void 0) {
     const sarif = await generateSarif(
       codeql,
@@ -74876,7 +74875,6 @@ async function runQuery(codeql, database, nwo, queryPack) {
     resultCount = getSarifResultCount(sarif);
     sarifFilePath = import_path.default.join("results", "results.sarif");
     import_fs3.default.writeFileSync(sarifFilePath, JSON.stringify(sarif));
-    sarifFileSize = import_fs3.default.statSync(sarifFilePath).size;
   } else {
     resultCount = getBqrsResultCount(bqrsInfo);
   }
@@ -74894,8 +74892,7 @@ async function runQuery(codeql, database, nwo, queryPack) {
     sourceLocationPrefix,
     metadataFilePath,
     bqrsFilePath,
-    sarifFilePath,
-    sarifFileSize
+    sarifFilePath
   };
 }
 async function downloadDatabase(repoId, repoName, language, pat) {

--- a/dist/query.js
+++ b/dist/query.js
@@ -74848,7 +74848,6 @@ async function runQuery(codeql, database, nwo, queryPack) {
   const bqrsFilePath = import_path.default.join("results", "results.bqrs");
   const tempBqrsFilePath = getBqrsFile(databaseName);
   import_fs3.default.renameSync(tempBqrsFilePath, bqrsFilePath);
-  const bqrsFileSize = import_fs3.default.statSync(bqrsFilePath).size;
   const bqrsInfo = await getBqrsInfo(codeql, bqrsFilePath);
   const compatibleQueryKinds = bqrsInfo.compatibleQueryKinds;
   const queryMetadata = await getQueryMetadata(
@@ -74895,7 +74894,6 @@ async function runQuery(codeql, database, nwo, queryPack) {
     sourceLocationPrefix,
     metadataFilePath,
     bqrsFilePath,
-    bqrsFileSize,
     sarifFilePath,
     sarifFileSize
   };

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -18,7 +18,6 @@ export interface RunQueryResult {
   metadataFilePath: string;
   bqrsFilePath: string;
   sarifFilePath?: string;
-  sarifFileSize?: number;
 }
 
 // Must be a valid value for "-t=kind" when doing "codeql bqrs interpret"
@@ -97,7 +96,6 @@ export async function runQuery(
   );
   let resultCount: number;
   let sarifFilePath: string | undefined;
-  let sarifFileSize: number | undefined;
   if (sarifOutputType !== undefined) {
     const sarif = await generateSarif(
       codeql,
@@ -112,7 +110,6 @@ export async function runQuery(
     resultCount = getSarifResultCount(sarif);
     sarifFilePath = path.join("results", "results.sarif");
     fs.writeFileSync(sarifFilePath, JSON.stringify(sarif));
-    sarifFileSize = fs.statSync(sarifFilePath).size;
   } else {
     resultCount = getBqrsResultCount(bqrsInfo);
   }
@@ -133,7 +130,6 @@ export async function runQuery(
     metadataFilePath,
     bqrsFilePath,
     sarifFilePath,
-    sarifFileSize,
   };
 }
 

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -17,7 +17,6 @@ export interface RunQueryResult {
   sourceLocationPrefix: string;
   metadataFilePath: string;
   bqrsFilePath: string;
-  bqrsFileSize: number;
   sarifFilePath?: string;
   sarifFileSize?: number;
 }
@@ -84,8 +83,6 @@ export async function runQuery(
   const tempBqrsFilePath = getBqrsFile(databaseName);
   fs.renameSync(tempBqrsFilePath, bqrsFilePath);
 
-  const bqrsFileSize = fs.statSync(bqrsFilePath).size;
-
   const bqrsInfo = await getBqrsInfo(codeql, bqrsFilePath);
   const compatibleQueryKinds = bqrsInfo.compatibleQueryKinds;
   const queryMetadata = await getQueryMetadata(
@@ -135,7 +132,6 @@ export async function runQuery(
     sourceLocationPrefix,
     metadataFilePath,
     bqrsFilePath,
-    bqrsFileSize,
     sarifFilePath,
     sarifFileSize,
   };


### PR DESCRIPTION
Remove `bqrsFileSize` and `sarifFileSize` from `RunQueryResult` as they don't actually seem to be used anywhere.