### PR TITLE
Add running tests section in CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,14 @@
 # Development guide
 
 - Install the recommended extensions for automatic formatting on save.
-- We use the [ava](https://github.com/avajs/ava) test runner. To run one or more specific test(s), use `npm run test -- -m <title>`.
-- The `codeql` executable must be on the path before running any tests.
 - All compiled artifacts should be checked in.
 - We recommend running `npm run watch` in the background to keep compiled artifacts up to date during development.
+
+## Running tests
+
+We use the [ava](https://github.com/avajs/ava) test runner. To run one or more specific test(s), use `npm run test -- -m <title>`.
+
+The `codeql` executable must be on the path before running any tests. If you run `script/test` instad of `npm run test` it will set that up automatically.
 
 # Generating sourcemaps
 


### PR DESCRIPTION
Added a call out to `script/test` that I wasn't aware of before @shati-patel mentioned it to me. 