### PR TITLE
Add tsbuildinfo file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /lib/
 /node_modules/
 /dist/*.js.map
+tsconfig.tsbuildinfo


### PR DESCRIPTION
The `tsconfig.tsbuildinfo` file has build information file generated by TypeScript, to help detect what has changed between compilations, allowing it to compile only the changed parts and thus speeding up the compilation process.

I don't think we should be checking this in, and since it's generated, I think it should be in .gitignore.