### PR TITLE
Read problems result set if '#select' result set doesn't exist

### DIFF
--- a/dist/query.js
+++ b/dist/query.js
@@ -75031,14 +75031,18 @@ function getSarifResultCount(sarif) {
   }
   return count;
 }
+var KNOWN_RESULT_SET_NAMES = ["#select", "problems"];
 function getBqrsResultCount(bqrsInfo) {
-  const selectResultSet = bqrsInfo.resultSets.find(
-    (resultSet) => resultSet.name === "#select"
-  );
-  if (!selectResultSet) {
-    throw new Error("No result set named #select");
+  for (const name of KNOWN_RESULT_SET_NAMES) {
+    const resultSet = bqrsInfo.resultSets.find((r) => r.name === name);
+    if (resultSet !== void 0) {
+      return resultSet.rows;
+    }
   }
-  return selectResultSet.rows;
+  const resultSetNames = bqrsInfo.resultSets.map((r) => r.name);
+  throw new Error(
+    `BQRS does not contain any result sets matching known names. Expected one of ${KNOWN_RESULT_SET_NAMES.join(" or ")} but found ${resultSetNames.join(", ")}`
+  );
 }
 function getDatabaseMetadata(database) {
   try {

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -450,16 +450,27 @@ export function getSarifResultCount(sarif: Sarif): number {
 }
 
 /**
+ * Names of result sets that can be considered the "default" result set
+ * and should be used when calculating number of results and when showing
+ * results to users.
+ */
+const KNOWN_RESULT_SET_NAMES: string[] = ["#select", "problems"];
+
+/**
  * Gets the number of results in the given BQRS data.
  */
-function getBqrsResultCount(bqrsInfo: BQRSInfo): number {
-  const selectResultSet = bqrsInfo.resultSets.find(
-    (resultSet) => resultSet.name === "#select",
-  );
-  if (!selectResultSet) {
-    throw new Error("No result set named #select");
+export function getBqrsResultCount(bqrsInfo: BQRSInfo): number {
+  for (const name of KNOWN_RESULT_SET_NAMES) {
+    const resultSet = bqrsInfo.resultSets.find((r) => r.name === name);
+    if (resultSet !== undefined) {
+      return resultSet.rows;
+    }
   }
-  return selectResultSet.rows;
+
+  const resultSetNames = bqrsInfo.resultSets.map((r) => r.name);
+  throw new Error(
+    `BQRS does not contain any result sets matching known names. Expected one of ${KNOWN_RESULT_SET_NAMES.join(" or ")} but found ${resultSetNames.join(", ")}`,
+  );
 }
 
 interface DatabaseMetadata {

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -453,6 +453,7 @@ export function getSarifResultCount(sarif: Sarif): number {
  * Names of result sets that can be considered the "default" result set
  * and should be used when calculating number of results and when showing
  * results to users.
+ * Will check result sets in this order and use the first one that exists.
  */
 const KNOWN_RESULT_SET_NAMES: string[] = ["#select", "problems"];
 


### PR DESCRIPTION
MRVA fails when running certain queries, such as [`IncompleteHostnameRegExp.ql`](https://github.com/github/codeql/blob/main/python/ql/src/Security/CWE-020/IncompleteHostnameRegExp.ql). This is because the resulting BQRS file doesn't contain a `#select` results set but instead contains one called `problems`.

This PR allows us to use either results set. In my manual searches, every query I've looked at has precisely one of these two.

I've tested this PR by confirming that `IncompleteHostnameRegExp.ql` fails when using the `main` branch of this repo, but passes when using this branch. I then also tested this branch with another `problem` query, a `path-problem` query, a `table` query, and also tried running against the published pack for python.

---

I've also opened an internal issue to look at reducing/removing our calls to `codeql bqrs info`, though I'm not sure we'll be able to remove them entirely, so we'll still want this fix in there.