### PR TITLE
Retry request timeout errors

### DIFF
--- a/dist/query.js
+++ b/dist/query.js
@@ -74854,6 +74854,9 @@ async function uploadArtifact(policy, artifactContents) {
       if (err instanceof HTTPError && err.httpStatusCode) {
         return err.httpStatusCode === 504;
       }
+      if (err.message.includes("Request timeout")) {
+        return true;
+      }
       return false;
     }
   );

--- a/src/azure-client.ts
+++ b/src/azure-client.ts
@@ -24,6 +24,13 @@ export async function uploadArtifact(
         return err.httpStatusCode === 504;
       }
 
+      if (err.message.includes("Request timeout")) {
+        // Retry on request timeout
+        // Error is created here:
+        // https://github.com/actions/toolkit/blob/415c42d27ca2a24f3801dd9406344aaea00b7866/packages/http-client/src/index.ts#L535
+        return true;
+      }
+
       // Otherwise abort
       return false;
     },


### PR DESCRIPTION
When we get a request timeout while uploading an artifact, a [request timeout error is created by the Actions HTTP client](https://github.com/actions/toolkit/blob/415c42d27ca2a24f3801dd9406344aaea00b7866/packages/http-client/src/index.ts#L535). We want to retry on this error since this is very likely to be transient. Unfortunately, it's not a custom error which we can check against, so we need to match against the message.