### PR TITLE
Simplify queryPackSupportsSarif and fix comment

### DIFF
--- a/dist/query.js
+++ b/dist/query.js
@@ -75220,16 +75220,9 @@ function querySupportsSarif(queryMetadata, bqrsInfo) {
   return sarifOutputType !== void 0;
 }
 function queryPackSupportsSarif(queriesResultInfo) {
-  for (const query of queriesResultInfo.queries) {
-    const supportsSarif = querySupportsSarif(
-      query.queryMetadata,
-      query.bqrsInfo
-    );
-    if (!supportsSarif) {
-      return false;
-    }
-  }
-  return true;
+  return queriesResultInfo.queries.every(
+    (q) => querySupportsSarif(q.queryMetadata, q.bqrsInfo)
+  );
 }
 function getSarifOutputType(queryMetadata, compatibleQueryKinds) {
   const queryKind = queryMetadata.kind;

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -329,11 +329,13 @@ function querySupportsSarif(
   return sarifOutputType !== undefined;
 }
 
+/**
+ * All queries in the pack must support SARIF in order
+ * for the query pack to support SARIF.
+ */
 function queryPackSupportsSarif(
   queriesResultInfo: QueryPackRunResults,
 ): boolean {
-  // Some queries in the pack must support SARIF in order
-  // for the query pack to support SARIF.
   for (const query of queriesResultInfo.queries) {
     const supportsSarif = querySupportsSarif(
       query.queryMetadata,

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -336,17 +336,9 @@ function querySupportsSarif(
 function queryPackSupportsSarif(
   queriesResultInfo: QueryPackRunResults,
 ): boolean {
-  for (const query of queriesResultInfo.queries) {
-    const supportsSarif = querySupportsSarif(
-      query.queryMetadata,
-      query.bqrsInfo,
-    );
-    if (!supportsSarif) {
-      return false;
-    }
-  }
-
-  return true;
+  return queriesResultInfo.queries.every((q) =>
+    querySupportsSarif(q.queryMetadata, q.bqrsInfo),
+  );
 }
 
 /**


### PR DESCRIPTION
This PR aims to make `queryPackSupportsSarif` easier to read, and fixes the comment which was unfortunately giving wrong information.