### PR TITLE
Use the CodeQL CLI server for running CodeQL commands

### DIFF
--- a/dist/query.js
+++ b/dist/query.js
@@ -15686,7 +15686,7 @@ var require_frame = __commonJS({
 var require_receiver = __commonJS({
   "node_modules/undici/lib/websocket/receiver.js"(exports2, module2) {
     "use strict";
-    var { Writable } = require("stream");
+    var { Writable: Writable2 } = require("stream");
     var diagnosticsChannel = require("diagnostics_channel");
     var { parserStates, opcodes, states, emptyBuffer } = require_constants4();
     var { kReadyState, kSentClose, kResponse, kReceivedClose } = require_symbols5();
@@ -15695,7 +15695,7 @@ var require_receiver = __commonJS({
     var channels = {};
     channels.ping = diagnosticsChannel.channel("undici:websocket:ping");
     channels.pong = diagnosticsChannel.channel("undici:websocket:pong");
-    var ByteParser = class extends Writable {
+    var ByteParser = class extends Writable2 {
       #buffers = [];
       #byteOffset = 0;
       #state = parserStates.INFO;
@@ -21309,7 +21309,7 @@ var require_stream_writable = __commonJS({
   "node_modules/readable-stream/lib/_stream_writable.js"(exports2, module2) {
     "use strict";
     var pna = require_process_nextick_args();
-    module2.exports = Writable;
+    module2.exports = Writable2;
     function CorkedRequest(state) {
       var _this = this;
       this.next = null;
@@ -21320,7 +21320,7 @@ var require_stream_writable = __commonJS({
     }
     var asyncWrite = !process.browser && ["v0.10", "v0.9."].indexOf(process.version.slice(0, 5)) > -1 ? setImmediate : pna.nextTick;
     var Duplex;
-    Writable.WritableState = WritableState;
+    Writable2.WritableState = WritableState;
     var util2 = Object.create(require_util8());
     util2.inherits = require_inherits();
     var internalUtil = {
@@ -21337,7 +21337,7 @@ var require_stream_writable = __commonJS({
       return Buffer2.isBuffer(obj) || obj instanceof OurUint8Array;
     }
     var destroyImpl = require_destroy();
-    util2.inherits(Writable, Stream);
+    util2.inherits(Writable2, Stream);
     function nop() {
     }
     function WritableState(options, stream2) {
@@ -21406,11 +21406,11 @@ var require_stream_writable = __commonJS({
     var realHasInstance;
     if (typeof Symbol === "function" && Symbol.hasInstance && typeof Function.prototype[Symbol.hasInstance] === "function") {
       realHasInstance = Function.prototype[Symbol.hasInstance];
-      Object.defineProperty(Writable, Symbol.hasInstance, {
+      Object.defineProperty(Writable2, Symbol.hasInstance, {
         value: function(object) {
           if (realHasInstance.call(this, object))
             return true;
-          if (this !== Writable)
+          if (this !== Writable2)
             return false;
           return object && object._writableState instanceof WritableState;
         }
@@ -21420,10 +21420,10 @@ var require_stream_writable = __commonJS({
         return object instanceof this;
       };
     }
-    function Writable(options) {
+    function Writable2(options) {
       Duplex = Duplex || require_stream_duplex();
-      if (!realHasInstance.call(Writable, this) && !(this instanceof Duplex)) {
-        return new Writable(options);
+      if (!realHasInstance.call(Writable2, this) && !(this instanceof Duplex)) {
+        return new Writable2(options);
       }
       this._writableState = new WritableState(options, this);
       this.writable = true;
@@ -21439,7 +21439,7 @@ var require_stream_writable = __commonJS({
       }
       Stream.call(this);
     }
-    Writable.prototype.pipe = function() {
+    Writable2.prototype.pipe = function() {
       this.emit("error", new Error("Cannot pipe, not readable"));
     };
     function writeAfterEnd(stream2, cb) {
@@ -21462,7 +21462,7 @@ var require_stream_writable = __commonJS({
       }
       return valid;
     }
-    Writable.prototype.write = function(chunk, encoding, cb) {
+    Writable2.prototype.write = function(chunk, encoding, cb) {
       var state = this._writableState;
       var ret = false;
       var isBuf = !state.objectMode && _isUint8Array(chunk);
@@ -21487,11 +21487,11 @@ var require_stream_writable = __commonJS({
       }
       return ret;
     };
-    Writable.prototype.cork = function() {
+    Writable2.prototype.cork = function() {
       var state = this._writableState;
       state.corked++;
     };
-    Writable.prototype.uncork = function() {
+    Writable2.prototype.uncork = function() {
       var state = this._writableState;
       if (state.corked) {
         state.corked--;
@@ -21499,7 +21499,7 @@ var require_stream_writable = __commonJS({
           clearBuffer(this, state);
       }
     };
-    Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
+    Writable2.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
       if (typeof encoding === "string")
         encoding = encoding.toLowerCase();
       if (!(["hex", "utf8", "utf-8", "ascii", "binary", "base64", "ucs2", "ucs-2", "utf16le", "utf-16le", "raw"].indexOf((encoding + "").toLowerCase()) > -1))
@@ -21513,7 +21513,7 @@ var require_stream_writable = __commonJS({
       }
       return chunk;
     }
-    Object.defineProperty(Writable.prototype, "writableHighWaterMark", {
+    Object.defineProperty(Writable2.prototype, "writableHighWaterMark", {
       // making it explicit this property is not enumerable
       // because otherwise some prototype manipulation in
       // userland will fail
@@ -21666,11 +21666,11 @@ var require_stream_writable = __commonJS({
       state.bufferedRequest = entry;
       state.bufferProcessing = false;
     }
-    Writable.prototype._write = function(chunk, encoding, cb) {
+    Writable2.prototype._write = function(chunk, encoding, cb) {
       cb(new Error("_write() is not implemented"));
     };
-    Writable.prototype._writev = null;
-    Writable.prototype.end = function(chunk, encoding, cb) {
+    Writable2.prototype._writev = null;
+    Writable2.prototype.end = function(chunk, encoding, cb) {
       var state = this._writableState;
       if (typeof chunk === "function") {
         cb = chunk;
@@ -21753,7 +21753,7 @@ var require_stream_writable = __commonJS({
         state.corkedRequestsFree = corkReq;
       }
     }
-    Object.defineProperty(Writable.prototype, "destroyed", {
+    Object.defineProperty(Writable2.prototype, "destroyed", {
       get: function() {
         if (this._writableState === void 0) {
           return false;
@@ -21767,9 +21767,9 @@ var require_stream_writable = __commonJS({
         this._writableState.destroyed = value;
       }
     });
-    Writable.prototype.destroy = destroyImpl.destroy;
-    Writable.prototype._undestroy = destroyImpl.undestroy;
-    Writable.prototype._destroy = function(err, cb) {
+    Writable2.prototype.destroy = destroyImpl.destroy;
+    Writable2.prototype._undestroy = destroyImpl.undestroy;
+    Writable2.prototype._destroy = function(err, cb) {
       this.end();
       cb(err);
     };
@@ -21792,14 +21792,14 @@ var require_stream_duplex = __commonJS({
     var util2 = Object.create(require_util8());
     util2.inherits = require_inherits();
     var Readable = require_stream_readable();
-    var Writable = require_stream_writable();
+    var Writable2 = require_stream_writable();
     util2.inherits(Duplex, Readable);
     {
-      keys = objectKeys(Writable.prototype);
+      keys = objectKeys(Writable2.prototype);
       for (v = 0; v < keys.length; v++) {
         method = keys[v];
         if (!Duplex.prototype[method])
-          Duplex.prototype[method] = Writable.prototype[method];
+          Duplex.prototype[method] = Writable2.prototype[method];
       }
     }
     var keys;
@@ -21809,7 +21809,7 @@ var require_stream_duplex = __commonJS({
       if (!(this instanceof Duplex))
         return new Duplex(options);
       Readable.call(this, options);
-      Writable.call(this, options);
+      Writable2.call(this, options);
       if (options && options.readable === false)
         this.readable = false;
       if (options && options.writable === false)
@@ -57955,7 +57955,7 @@ var require_frame2 = __commonJS({
 var require_receiver2 = __commonJS({
   "node_modules/@octokit/action/node_modules/undici/lib/websocket/receiver.js"(exports2, module2) {
     "use strict";
-    var { Writable } = require("stream");
+    var { Writable: Writable2 } = require("stream");
     var diagnosticsChannel = require("diagnostics_channel");
     var { parserStates, opcodes, states, emptyBuffer } = require_constants10();
     var { kReadyState, kSentClose, kResponse, kReceivedClose } = require_symbols10();
@@ -57964,7 +57964,7 @@ var require_receiver2 = __commonJS({
     var channels = {};
     channels.ping = diagnosticsChannel.channel("undici:websocket:ping");
     channels.pong = diagnosticsChannel.channel("undici:websocket:pong");
-    var ByteParser = class extends Writable {
+    var ByteParser = class extends Writable2 {
       #buffers = [];
       #byteOffset = 0;
       #state = parserStates.INFO;
@@ -75351,6 +75351,7 @@ function getQueryPackName(queryPackPath) {
 // src/codeql-cli.ts
 var import_node_child_process = require("node:child_process");
 var import_node_os = require("node:os");
+var import_node_stream = require("node:stream");
 var import_core2 = __toESM(require_core());
 var import_exec = __toESM(require_exec());
 var BaseCodeqlCli = class {
@@ -75436,6 +75437,7 @@ var CodeqlCliServer = class {
   }
   async runCommandImmediately(args) {
     const stderrBuffers = [];
+    const parentProcess = process;
     if (this.commandInProcess) {
       throw new Error(
         "runCommandImmediately called while command was in process"
@@ -75451,14 +75453,30 @@ var CodeqlCliServer = class {
       void (0, import_core2.debug)(`Running using CodeQL CLI: ${args.join(" ")}`);
       try {
         await new Promise((resolve, reject) => {
+          let parentStdout;
+          if (parentProcess.stdout instanceof import_node_stream.Writable) {
+            parentStdout = parentProcess.stdout;
+          }
+          let parentStderr = void 0;
+          if (parentProcess.stderr instanceof import_node_stream.Writable) {
+            parentStderr = parentProcess.stderr;
+          }
           process2.stdout.addListener("data", (newData) => {
             stdoutBuffers.push(newData);
+            if (newData.length > 0 && newData.readUInt8(newData.length - 1) === 0) {
+              if (newData.length > 1) {
+                parentStdout?.write(newData.subarray(0, newData.length - 1));
+              }
+            } else {
+              parentStdout?.write(newData);
+            }
             if (newData.length > 0 && newData.readUInt8(newData.length - 1) === 0) {
               resolve();
             }
           });
           process2.stderr.addListener("data", (newData) => {
             stderrBuffers.push(newData);
+            parentStderr?.write(newData);
           });
           process2.addListener(
             "close",

--- a/dist/query.js
+++ b/dist/query.js
@@ -723,7 +723,7 @@ var require_tunnel = __commonJS({
         connectOptions.headers = connectOptions.headers || {};
         connectOptions.headers["Proxy-Authorization"] = "Basic " + new Buffer(connectOptions.proxyAuth).toString("base64");
       }
-      debug2("making CONNECT request");
+      debug3("making CONNECT request");
       var connectReq = self2.request(connectOptions);
       connectReq.useChunkedEncodingByDefault = false;
       connectReq.once("response", onResponse);
@@ -743,40 +743,40 @@ var require_tunnel = __commonJS({
         connectReq.removeAllListeners();
         socket.removeAllListeners();
         if (res.statusCode !== 200) {
-          debug2(
+          debug3(
             "tunneling socket could not be established, statusCode=%d",
             res.statusCode
           );
           socket.destroy();
-          var error = new Error("tunneling socket could not be established, statusCode=" + res.statusCode);
-          error.code = "ECONNRESET";
-          options.request.emit("error", error);
+          var error2 = new Error("tunneling socket could not be established, statusCode=" + res.statusCode);
+          error2.code = "ECONNRESET";
+          options.request.emit("error", error2);
           self2.removeSocket(placeholder);
           return;
         }
         if (head.length > 0) {
-          debug2("got illegal response body from proxy");
+          debug3("got illegal response body from proxy");
           socket.destroy();
-          var error = new Error("got illegal response body from proxy");
-          error.code = "ECONNRESET";
-          options.request.emit("error", error);
+          var error2 = new Error("got illegal response body from proxy");
+          error2.code = "ECONNRESET";
+          options.request.emit("error", error2);
           self2.removeSocket(placeholder);
           return;
         }
-        debug2("tunneling connection has established");
+        debug3("tunneling connection has established");
         self2.sockets[self2.sockets.indexOf(placeholder)] = socket;
         return cb(socket);
       }
       function onError(cause) {
         connectReq.removeAllListeners();
-        debug2(
+        debug3(
           "tunneling socket could not be established, cause=%s\n",
           cause.message,
           cause.stack
         );
-        var error = new Error("tunneling socket could not be established, cause=" + cause.message);
-        error.code = "ECONNRESET";
-        options.request.emit("error", error);
+        var error2 = new Error("tunneling socket could not be established, cause=" + cause.message);
+        error2.code = "ECONNRESET";
+        options.request.emit("error", error2);
         self2.removeSocket(placeholder);
       }
     };
@@ -831,9 +831,9 @@ var require_tunnel = __commonJS({
       }
       return target;
     }
-    var debug2;
+    var debug3;
     if (process.env.NODE_DEBUG && /\btunnel\b/.test(process.env.NODE_DEBUG)) {
-      debug2 = function() {
+      debug3 = function() {
         var args = Array.prototype.slice.call(arguments);
         if (typeof args[0] === "string") {
           args[0] = "TUNNEL: " + args[0];
@@ -843,10 +843,10 @@ var require_tunnel = __commonJS({
         console.error.apply(console, args);
       };
     } else {
-      debug2 = function() {
+      debug3 = function() {
       };
     }
-    exports2.debug = debug2;
+    exports2.debug = debug3;
   }
 });
 
@@ -5105,7 +5105,7 @@ Content-Type: ${value.type || "application/octet-stream"}\r
         throw new TypeError("Body is unusable");
       }
       const promise = createDeferredPromise();
-      const errorSteps = (error) => promise.reject(error);
+      const errorSteps = (error2) => promise.reject(error2);
       const successSteps = (data) => {
         try {
           promise.resolve(convertBytesToJSValue(data));
@@ -5349,15 +5349,15 @@ var require_request = __commonJS({
         }
         return this[kHandler].onComplete(trailers);
       }
-      onError(error) {
+      onError(error2) {
         if (channels.error.hasSubscribers) {
-          channels.error.publish({ request: this, error });
+          channels.error.publish({ request: this, error: error2 });
         }
         if (this.aborted) {
           return;
         }
         this.aborted = true;
-        return this[kHandler].onError(error);
+        return this[kHandler].onError(error2);
       }
       // TODO: adjust to support H2
       addHeader(key, value) {
@@ -6219,8 +6219,8 @@ var require_RedirectHandler = __commonJS({
       onUpgrade(statusCode, headers, socket) {
         this.handler.onUpgrade(statusCode, headers, socket);
       }
-      onError(error) {
-        this.handler.onError(error);
+      onError(error2) {
+        this.handler.onError(error2);
       }
       onHeaders(statusCode, headers, resume, statusText) {
         this.location = this.history.length >= this.maxRedirections || util2.isDisturbed(this.opts.body) ? null : parseLocation(statusCode, headers);
@@ -9957,13 +9957,13 @@ var require_mock_utils = __commonJS({
       if (mockDispatch2.data.callback) {
         mockDispatch2.data = { ...mockDispatch2.data, ...mockDispatch2.data.callback(opts) };
       }
-      const { data: { statusCode, data, headers, trailers, error }, delay, persist } = mockDispatch2;
+      const { data: { statusCode, data, headers, trailers, error: error2 }, delay, persist } = mockDispatch2;
       const { timesInvoked, times } = mockDispatch2;
       mockDispatch2.consumed = !persist && timesInvoked >= times;
       mockDispatch2.pending = timesInvoked < times;
-      if (error !== null) {
+      if (error2 !== null) {
         deleteMockDispatch(this[kDispatches], key);
-        handler.onError(error);
+        handler.onError(error2);
         return true;
       }
       if (typeof delay === "number" && delay > 0) {
@@ -10001,19 +10001,19 @@ var require_mock_utils = __commonJS({
         if (agent.isMockActive) {
           try {
             mockDispatch.call(this, opts, handler);
-          } catch (error) {
-            if (error instanceof MockNotMatchedError) {
+          } catch (error2) {
+            if (error2 instanceof MockNotMatchedError) {
               const netConnect = agent[kGetNetConnect]();
               if (netConnect === false) {
-                throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect disabled)`);
+                throw new MockNotMatchedError(`${error2.message}: subsequent request to origin ${origin} was not allowed (net.connect disabled)`);
               }
               if (checkNetConnect(netConnect, origin)) {
                 originalDispatch.call(this, opts, handler);
               } else {
-                throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect is not enabled for this origin)`);
+                throw new MockNotMatchedError(`${error2.message}: subsequent request to origin ${origin} was not allowed (net.connect is not enabled for this origin)`);
               }
             } else {
-              throw error;
+              throw error2;
             }
           }
         } else {
@@ -10176,11 +10176,11 @@ var require_mock_interceptor = __commonJS({
       /**
        * Mock an undici request with a defined error.
        */
-      replyWithError(error) {
-        if (typeof error === "undefined") {
+      replyWithError(error2) {
+        if (typeof error2 === "undefined") {
           throw new InvalidArgumentError("error must be defined");
         }
-        const newMockDispatch = addMockDispatch(this[kDispatches], this[kDispatchKey], { error });
+        const newMockDispatch = addMockDispatch(this[kDispatches], this[kDispatchKey], { error: error2 });
         return new MockScope(newMockDispatch);
       }
       /**
@@ -12197,17 +12197,17 @@ var require_fetch = __commonJS({
         this.emit("terminated", reason);
       }
       // https://fetch.spec.whatwg.org/#fetch-controller-abort
-      abort(error) {
+      abort(error2) {
         if (this.state !== "ongoing") {
           return;
         }
         this.state = "aborted";
-        if (!error) {
-          error = new DOMException2("The operation was aborted.", "AbortError");
+        if (!error2) {
+          error2 = new DOMException2("The operation was aborted.", "AbortError");
         }
-        this.serializedAbortReason = error;
-        this.connection?.destroy(error);
-        this.emit("terminated", error);
+        this.serializedAbortReason = error2;
+        this.connection?.destroy(error2);
+        this.emit("terminated", error2);
       }
     };
     async function fetch(input, init = {}) {
@@ -12311,13 +12311,13 @@ var require_fetch = __commonJS({
         performance.markResourceTiming(timingInfo, originalURL.href, initiatorType, globalThis2, cacheState);
       }
     }
-    function abortFetch(p, request, responseObject, error) {
-      if (!error) {
-        error = new DOMException2("The operation was aborted.", "AbortError");
+    function abortFetch(p, request, responseObject, error2) {
+      if (!error2) {
+        error2 = new DOMException2("The operation was aborted.", "AbortError");
       }
-      p.reject(error);
+      p.reject(error2);
       if (request.body != null && isReadable(request.body?.stream)) {
-        request.body.stream.cancel(error).catch((err) => {
+        request.body.stream.cancel(error2).catch((err) => {
           if (err.code === "ERR_INVALID_STATE") {
             return;
           }
@@ -12329,7 +12329,7 @@ var require_fetch = __commonJS({
       }
       const response = responseObject[kState];
       if (response.body != null && isReadable(response.body?.stream)) {
-        response.body.stream.cancel(error).catch((err) => {
+        response.body.stream.cancel(error2).catch((err) => {
           if (err.code === "ERR_INVALID_STATE") {
             return;
           }
@@ -13107,13 +13107,13 @@ var require_fetch = __commonJS({
               fetchParams.controller.ended = true;
               this.body.push(null);
             },
-            onError(error) {
+            onError(error2) {
               if (this.abort) {
                 fetchParams.controller.off("terminated", this.abort);
               }
-              this.body?.destroy(error);
-              fetchParams.controller.terminate(error);
-              reject(error);
+              this.body?.destroy(error2);
+              fetchParams.controller.terminate(error2);
+              reject(error2);
             },
             onUpgrade(status, headersList, socket) {
               if (status !== 101) {
@@ -13579,8 +13579,8 @@ var require_util4 = __commonJS({
                   }
                   fr[kResult] = result;
                   fireAProgressEvent("load", fr);
-                } catch (error) {
-                  fr[kError] = error;
+                } catch (error2) {
+                  fr[kError] = error2;
                   fireAProgressEvent("error", fr);
                 }
                 if (fr[kState] !== "loading") {
@@ -13589,13 +13589,13 @@ var require_util4 = __commonJS({
               });
               break;
             }
-          } catch (error) {
+          } catch (error2) {
             if (fr[kAborted]) {
               return;
             }
             queueMicrotask(() => {
               fr[kState] = "done";
-              fr[kError] = error;
+              fr[kError] = error2;
               fireAProgressEvent("error", fr);
               if (fr[kState] !== "loading") {
                 fireAProgressEvent("loadend", fr);
@@ -15611,11 +15611,11 @@ var require_connection = __commonJS({
         });
       }
     }
-    function onSocketError(error) {
+    function onSocketError(error2) {
       const { ws } = this;
       ws[kReadyState] = states.CLOSING;
       if (channels.socketError.hasSubscribers) {
-        channels.socketError.publish(error);
+        channels.socketError.publish(error2);
       }
       this.destroy();
     }
@@ -17253,12 +17253,12 @@ var require_oidc_utils = __commonJS({
         var _a;
         return __awaiter(this, void 0, void 0, function* () {
           const httpclient = _OidcClient.createHttpClient();
-          const res = yield httpclient.getJson(id_token_url).catch((error) => {
+          const res = yield httpclient.getJson(id_token_url).catch((error2) => {
             throw new Error(`Failed to get ID Token. 
  
-        Error Code : ${error.statusCode}
+        Error Code : ${error2.statusCode}
  
-        Error Message: ${error.message}`);
+        Error Message: ${error2.message}`);
           });
           const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
           if (!id_token) {
@@ -17279,8 +17279,8 @@ var require_oidc_utils = __commonJS({
             const id_token = yield _OidcClient.getCall(id_token_url);
             core_1.setSecret(id_token);
             return id_token;
-          } catch (error) {
-            throw new Error(`Error message: ${error.message}`);
+          } catch (error2) {
+            throw new Error(`Error message: ${error2.message}`);
           }
         });
       }
@@ -17775,21 +17775,21 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     exports2.setCommandEcho = setCommandEcho;
     function setFailed2(message) {
       process.exitCode = ExitCode.Failure;
-      error(message);
+      error2(message);
     }
     exports2.setFailed = setFailed2;
     function isDebug() {
       return process.env["RUNNER_DEBUG"] === "1";
     }
     exports2.isDebug = isDebug;
-    function debug2(message) {
+    function debug3(message) {
       command_1.issueCommand("debug", {}, message);
     }
-    exports2.debug = debug2;
-    function error(message, properties = {}) {
+    exports2.debug = debug3;
+    function error2(message, properties = {}) {
       command_1.issueCommand("error", utils_1.toCommandProperties(properties), message instanceof Error ? message.toString() : message);
     }
-    exports2.error = error;
+    exports2.error = error2;
     function warning2(message, properties = {}) {
       command_1.issueCommand("warning", utils_1.toCommandProperties(properties), message instanceof Error ? message.toString() : message);
     }
@@ -18297,15 +18297,15 @@ var require_io = __commonJS({
 var require_semver = __commonJS({
   "node_modules/semver/semver.js"(exports2, module2) {
     exports2 = module2.exports = SemVer;
-    var debug2;
+    var debug3;
     if (typeof process === "object" && process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG)) {
-      debug2 = function() {
+      debug3 = function() {
         var args = Array.prototype.slice.call(arguments, 0);
         args.unshift("SEMVER");
         console.log.apply(console, args);
       };
     } else {
-      debug2 = function() {
+      debug3 = function() {
       };
     }
     exports2.SEMVER_SPEC_VERSION = "2.0.0";
@@ -18423,7 +18423,7 @@ var require_semver = __commonJS({
     tok("STAR");
     src[t.STAR] = "(<|>)?=?\\s*\\*";
     for (i = 0; i < R; i++) {
-      debug2(i, src[i]);
+      debug3(i, src[i]);
       if (!re[i]) {
         re[i] = new RegExp(src[i]);
         safeRe[i] = new RegExp(makeSafeRe(src[i]));
@@ -18490,7 +18490,7 @@ var require_semver = __commonJS({
       if (!(this instanceof SemVer)) {
         return new SemVer(version2, options);
       }
-      debug2("SemVer", version2, options);
+      debug3("SemVer", version2, options);
       this.options = options;
       this.loose = !!options.loose;
       var m = version2.trim().match(options.loose ? safeRe[t.LOOSE] : safeRe[t.FULL]);
@@ -18537,7 +18537,7 @@ var require_semver = __commonJS({
       return this.version;
     };
     SemVer.prototype.compare = function(other) {
-      debug2("SemVer.compare", this.version, this.options, other);
+      debug3("SemVer.compare", this.version, this.options, other);
       if (!(other instanceof SemVer)) {
         other = new SemVer(other, this.options);
       }
@@ -18564,7 +18564,7 @@ var require_semver = __commonJS({
       do {
         var a = this.prerelease[i2];
         var b = other.prerelease[i2];
-        debug2("prerelease compare", i2, a, b);
+        debug3("prerelease compare", i2, a, b);
         if (a === void 0 && b === void 0) {
           return 0;
         } else if (b === void 0) {
@@ -18586,7 +18586,7 @@ var require_semver = __commonJS({
       do {
         var a = this.build[i2];
         var b = other.build[i2];
-        debug2("prerelease compare", i2, a, b);
+        debug3("prerelease compare", i2, a, b);
         if (a === void 0 && b === void 0) {
           return 0;
         } else if (b === void 0) {
@@ -18846,7 +18846,7 @@ var require_semver = __commonJS({
         return new Comparator(comp, options);
       }
       comp = comp.trim().split(/\s+/).join(" ");
-      debug2("comparator", comp, options);
+      debug3("comparator", comp, options);
       this.options = options;
       this.loose = !!options.loose;
       this.parse(comp);
@@ -18855,7 +18855,7 @@ var require_semver = __commonJS({
       } else {
         this.value = this.operator + this.semver.version;
       }
-      debug2("comp", this);
+      debug3("comp", this);
     }
     var ANY = {};
     Comparator.prototype.parse = function(comp) {
@@ -18878,7 +18878,7 @@ var require_semver = __commonJS({
       return this.value;
     };
     Comparator.prototype.test = function(version2) {
-      debug2("Comparator.test", version2, this.options.loose);
+      debug3("Comparator.test", version2, this.options.loose);
       if (this.semver === ANY || version2 === ANY) {
         return true;
       }
@@ -18971,9 +18971,9 @@ var require_semver = __commonJS({
       var loose = this.options.loose;
       var hr = loose ? safeRe[t.HYPHENRANGELOOSE] : safeRe[t.HYPHENRANGE];
       range = range.replace(hr, hyphenReplace);
-      debug2("hyphen replace", range);
+      debug3("hyphen replace", range);
       range = range.replace(safeRe[t.COMPARATORTRIM], comparatorTrimReplace);
-      debug2("comparator trim", range, safeRe[t.COMPARATORTRIM]);
+      debug3("comparator trim", range, safeRe[t.COMPARATORTRIM]);
       range = range.replace(safeRe[t.TILDETRIM], tildeTrimReplace);
       range = range.replace(safeRe[t.CARETTRIM], caretTrimReplace);
       range = range.split(/\s+/).join(" ");
@@ -19026,15 +19026,15 @@ var require_semver = __commonJS({
       });
     }
     function parseComparator(comp, options) {
-      debug2("comp", comp, options);
+      debug3("comp", comp, options);
       comp = replaceCarets(comp, options);
-      debug2("caret", comp);
+      debug3("caret", comp);
       comp = replaceTildes(comp, options);
-      debug2("tildes", comp);
+      debug3("tildes", comp);
       comp = replaceXRanges(comp, options);
-      debug2("xrange", comp);
+      debug3("xrange", comp);
       comp = replaceStars(comp, options);
-      debug2("stars", comp);
+      debug3("stars", comp);
       return comp;
     }
     function isX(id) {
@@ -19048,7 +19048,7 @@ var require_semver = __commonJS({
     function replaceTilde(comp, options) {
       var r = options.loose ? safeRe[t.TILDELOOSE] : safeRe[t.TILDE];
       return comp.replace(r, function(_, M, m, p, pr) {
-        debug2("tilde", comp, _, M, m, p, pr);
+        debug3("tilde", comp, _, M, m, p, pr);
         var ret;
         if (isX(M)) {
           ret = "";
@@ -19057,12 +19057,12 @@ var require_semver = __commonJS({
         } else if (isX(p)) {
           ret = ">=" + M + "." + m + ".0 <" + M + "." + (+m + 1) + ".0";
         } else if (pr) {
-          debug2("replaceTilde pr", pr);
+          debug3("replaceTilde pr", pr);
           ret = ">=" + M + "." + m + "." + p + "-" + pr + " <" + M + "." + (+m + 1) + ".0";
         } else {
           ret = ">=" + M + "." + m + "." + p + " <" + M + "." + (+m + 1) + ".0";
         }
-        debug2("tilde return", ret);
+        debug3("tilde return", ret);
         return ret;
       });
     }
@@ -19072,10 +19072,10 @@ var require_semver = __commonJS({
       }).join(" ");
     }
     function replaceCaret(comp, options) {
-      debug2("caret", comp, options);
+      debug3("caret", comp, options);
       var r = options.loose ? safeRe[t.CARETLOOSE] : safeRe[t.CARET];
       return comp.replace(r, function(_, M, m, p, pr) {
-        debug2("caret", comp, _, M, m, p, pr);
+        debug3("caret", comp, _, M, m, p, pr);
         var ret;
         if (isX(M)) {
           ret = "";
@@ -19088,7 +19088,7 @@ var require_semver = __commonJS({
             ret = ">=" + M + "." + m + ".0 <" + (+M + 1) + ".0.0";
           }
         } else if (pr) {
-          debug2("replaceCaret pr", pr);
+          debug3("replaceCaret pr", pr);
           if (M === "0") {
             if (m === "0") {
               ret = ">=" + M + "." + m + "." + p + "-" + pr + " <" + M + "." + m + "." + (+p + 1);
@@ -19099,7 +19099,7 @@ var require_semver = __commonJS({
             ret = ">=" + M + "." + m + "." + p + "-" + pr + " <" + (+M + 1) + ".0.0";
           }
         } else {
-          debug2("no pr");
+          debug3("no pr");
           if (M === "0") {
             if (m === "0") {
               ret = ">=" + M + "." + m + "." + p + " <" + M + "." + m + "." + (+p + 1);
@@ -19110,12 +19110,12 @@ var require_semver = __commonJS({
             ret = ">=" + M + "." + m + "." + p + " <" + (+M + 1) + ".0.0";
           }
         }
-        debug2("caret return", ret);
+        debug3("caret return", ret);
         return ret;
       });
     }
     function replaceXRanges(comp, options) {
-      debug2("replaceXRanges", comp, options);
+      debug3("replaceXRanges", comp, options);
       return comp.split(/\s+/).map(function(comp2) {
         return replaceXRange(comp2, options);
       }).join(" ");
@@ -19124,7 +19124,7 @@ var require_semver = __commonJS({
       comp = comp.trim();
       var r = options.loose ? safeRe[t.XRANGELOOSE] : safeRe[t.XRANGE];
       return comp.replace(r, function(ret, gtlt, M, m, p, pr) {
-        debug2("xRange", comp, ret, gtlt, M, m, p, pr);
+        debug3("xRange", comp, ret, gtlt, M, m, p, pr);
         var xM = isX(M);
         var xm = xM || isX(m);
         var xp = xm || isX(p);
@@ -19168,12 +19168,12 @@ var require_semver = __commonJS({
         } else if (xp) {
           ret = ">=" + M + "." + m + ".0" + pr + " <" + M + "." + (+m + 1) + ".0" + pr;
         }
-        debug2("xRange return", ret);
+        debug3("xRange return", ret);
         return ret;
       });
     }
     function replaceStars(comp, options) {
-      debug2("replaceStars", comp, options);
+      debug3("replaceStars", comp, options);
       return comp.trim().replace(safeRe[t.STAR], "");
     }
     function hyphenReplace($0, from, fM, fm, fp, fpr, fb, to, tM, tm, tp, tpr, tb) {
@@ -19225,7 +19225,7 @@ var require_semver = __commonJS({
       }
       if (version2.prerelease.length && !options.includePrerelease) {
         for (i2 = 0; i2 < set.length; i2++) {
-          debug2(set[i2].semver);
+          debug3(set[i2].semver);
           if (set[i2].semver === ANY) {
             continue;
           }
@@ -20011,7 +20011,7 @@ var require_toolrunner = __commonJS({
               this._debug(`STDIO streams have closed for tool '${this.toolPath}'`);
               state.CheckComplete();
             });
-            state.on("done", (error, exitCode) => {
+            state.on("done", (error2, exitCode) => {
               if (stdbuffer.length > 0) {
                 this.emit("stdline", stdbuffer);
               }
@@ -20019,8 +20019,8 @@ var require_toolrunner = __commonJS({
                 this.emit("errline", errbuffer);
               }
               cp.removeAllListeners();
-              if (error) {
-                reject(error);
+              if (error2) {
+                reject(error2);
               } else {
                 resolve(exitCode);
               }
@@ -20115,14 +20115,14 @@ var require_toolrunner = __commonJS({
         this.emit("debug", message);
       }
       _setResult() {
-        let error;
+        let error2;
         if (this.processExited) {
           if (this.processError) {
-            error = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
+            error2 = new Error(`There was an error when attempting to execute the process '${this.toolPath}'. This may indicate the process failed to start. Error: ${this.processError}`);
           } else if (this.processExitCode !== 0 && !this.options.ignoreReturnCode) {
-            error = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
+            error2 = new Error(`The process '${this.toolPath}' failed with exit code ${this.processExitCode}`);
           } else if (this.processStderr && this.options.failOnStdErr) {
-            error = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
+            error2 = new Error(`The process '${this.toolPath}' failed because one or more lines were written to the STDERR stream`);
           }
         }
         if (this.timeout) {
@@ -20130,7 +20130,7 @@ var require_toolrunner = __commonJS({
           this.timeout = null;
         }
         this.done = true;
-        this.emit("done", error, this.processExitCode);
+        this.emit("done", error2, this.processExitCode);
       }
       static HandleTimeout(state) {
         if (state.done) {
@@ -22145,11 +22145,11 @@ var require_stream_readable = __commonJS({
     var util2 = Object.create(require_util8());
     util2.inherits = require_inherits();
     var debugUtil = require("util");
-    var debug2 = void 0;
+    var debug3 = void 0;
     if (debugUtil && debugUtil.debuglog) {
-      debug2 = debugUtil.debuglog("stream");
+      debug3 = debugUtil.debuglog("stream");
     } else {
-      debug2 = function() {
+      debug3 = function() {
       };
     }
     var BufferList = require_BufferList();
@@ -22376,14 +22376,14 @@ var require_stream_readable = __commonJS({
       return state.length;
     }
     Readable.prototype.read = function(n) {
-      debug2("read", n);
+      debug3("read", n);
       n = parseInt(n, 10);
       var state = this._readableState;
       var nOrig = n;
       if (n !== 0)
         state.emittedReadable = false;
       if (n === 0 && state.needReadable && (state.length >= state.highWaterMark || state.ended)) {
-        debug2("read: emitReadable", state.length, state.ended);
+        debug3("read: emitReadable", state.length, state.ended);
         if (state.length === 0 && state.ended)
           endReadable(this);
         else
@@ -22397,16 +22397,16 @@ var require_stream_readable = __commonJS({
         return null;
       }
       var doRead = state.needReadable;
-      debug2("need readable", doRead);
+      debug3("need readable", doRead);
       if (state.length === 0 || state.length - n < state.highWaterMark) {
         doRead = true;
-        debug2("length less than watermark", doRead);
+        debug3("length less than watermark", doRead);
       }
       if (state.ended || state.reading) {
         doRead = false;
-        debug2("reading or ended", doRead);
+        debug3("reading or ended", doRead);
       } else if (doRead) {
-        debug2("do read");
+        debug3("do read");
         state.reading = true;
         state.sync = true;
         if (state.length === 0)
@@ -22454,7 +22454,7 @@ var require_stream_readable = __commonJS({
       var state = stream2._readableState;
       state.needReadable = false;
       if (!state.emittedReadable) {
-        debug2("emitReadable", state.flowing);
+        debug3("emitReadable", state.flowing);
         state.emittedReadable = true;
         if (state.sync)
           pna.nextTick(emitReadable_, stream2);
@@ -22463,7 +22463,7 @@ var require_stream_readable = __commonJS({
       }
     }
     function emitReadable_(stream2) {
-      debug2("emit readable");
+      debug3("emit readable");
       stream2.emit("readable");
       flow(stream2);
     }
@@ -22476,7 +22476,7 @@ var require_stream_readable = __commonJS({
     function maybeReadMore_(stream2, state) {
       var len = state.length;
       while (!state.reading && !state.flowing && !state.ended && state.length < state.highWaterMark) {
-        debug2("maybeReadMore read 0");
+        debug3("maybeReadMore read 0");
         stream2.read(0);
         if (len === state.length)
           break;
@@ -22503,7 +22503,7 @@ var require_stream_readable = __commonJS({
           break;
       }
       state.pipesCount += 1;
-      debug2("pipe count=%d opts=%j", state.pipesCount, pipeOpts);
+      debug3("pipe count=%d opts=%j", state.pipesCount, pipeOpts);
       var doEnd = (!pipeOpts || pipeOpts.end !== false) && dest !== process.stdout && dest !== process.stderr;
       var endFn = doEnd ? onend : unpipe;
       if (state.endEmitted)
@@ -22512,7 +22512,7 @@ var require_stream_readable = __commonJS({
         src.once("end", endFn);
       dest.on("unpipe", onunpipe);
       function onunpipe(readable, unpipeInfo) {
-        debug2("onunpipe");
+        debug3("onunpipe");
         if (readable === src) {
           if (unpipeInfo && unpipeInfo.hasUnpiped === false) {
             unpipeInfo.hasUnpiped = true;
@@ -22521,14 +22521,14 @@ var require_stream_readable = __commonJS({
         }
       }
       function onend() {
-        debug2("onend");
+        debug3("onend");
         dest.end();
       }
       var ondrain = pipeOnDrain(src);
       dest.on("drain", ondrain);
       var cleanedUp = false;
       function cleanup() {
-        debug2("cleanup");
+        debug3("cleanup");
         dest.removeListener("close", onclose);
         dest.removeListener("finish", onfinish);
         dest.removeListener("drain", ondrain);
@@ -22544,12 +22544,12 @@ var require_stream_readable = __commonJS({
       var increasedAwaitDrain = false;
       src.on("data", ondata);
       function ondata(chunk) {
-        debug2("ondata");
+        debug3("ondata");
         increasedAwaitDrain = false;
         var ret = dest.write(chunk);
         if (false === ret && !increasedAwaitDrain) {
           if ((state.pipesCount === 1 && state.pipes === dest || state.pipesCount > 1 && indexOf(state.pipes, dest) !== -1) && !cleanedUp) {
-            debug2("false write response, pause", src._readableState.awaitDrain);
+            debug3("false write response, pause", src._readableState.awaitDrain);
             src._readableState.awaitDrain++;
             increasedAwaitDrain = true;
           }
@@ -22557,7 +22557,7 @@ var require_stream_readable = __commonJS({
         }
       }
       function onerror(er) {
-        debug2("onerror", er);
+        debug3("onerror", er);
         unpipe();
         dest.removeListener("error", onerror);
         if (EElistenerCount(dest, "error") === 0)
@@ -22570,18 +22570,18 @@ var require_stream_readable = __commonJS({
       }
       dest.once("close", onclose);
       function onfinish() {
-        debug2("onfinish");
+        debug3("onfinish");
         dest.removeListener("close", onclose);
         unpipe();
       }
       dest.once("finish", onfinish);
       function unpipe() {
-        debug2("unpipe");
+        debug3("unpipe");
         src.unpipe(dest);
       }
       dest.emit("pipe", src);
       if (!state.flowing) {
-        debug2("pipe resume");
+        debug3("pipe resume");
         src.resume();
       }
       return dest;
@@ -22589,7 +22589,7 @@ var require_stream_readable = __commonJS({
     function pipeOnDrain(src) {
       return function() {
         var state = src._readableState;
-        debug2("pipeOnDrain", state.awaitDrain);
+        debug3("pipeOnDrain", state.awaitDrain);
         if (state.awaitDrain)
           state.awaitDrain--;
         if (state.awaitDrain === 0 && EElistenerCount(src, "data")) {
@@ -22657,13 +22657,13 @@ var require_stream_readable = __commonJS({
     };
     Readable.prototype.addListener = Readable.prototype.on;
     function nReadingNextTick(self2) {
-      debug2("readable nexttick read 0");
+      debug3("readable nexttick read 0");
       self2.read(0);
     }
     Readable.prototype.resume = function() {
       var state = this._readableState;
       if (!state.flowing) {
-        debug2("resume");
+        debug3("resume");
         state.flowing = true;
         resume(this, state);
       }
@@ -22677,7 +22677,7 @@ var require_stream_readable = __commonJS({
     }
     function resume_(stream2, state) {
       if (!state.reading) {
-        debug2("resume read 0");
+        debug3("resume read 0");
         stream2.read(0);
       }
       state.resumeScheduled = false;
@@ -22688,9 +22688,9 @@ var require_stream_readable = __commonJS({
         stream2.read(0);
     }
     Readable.prototype.pause = function() {
-      debug2("call pause flowing=%j", this._readableState.flowing);
+      debug3("call pause flowing=%j", this._readableState.flowing);
       if (false !== this._readableState.flowing) {
-        debug2("pause");
+        debug3("pause");
         this._readableState.flowing = false;
         this.emit("pause");
       }
@@ -22698,7 +22698,7 @@ var require_stream_readable = __commonJS({
     };
     function flow(stream2) {
       var state = stream2._readableState;
-      debug2("flow", state.flowing);
+      debug3("flow", state.flowing);
       while (state.flowing && stream2.read() !== null) {
       }
     }
@@ -22707,7 +22707,7 @@ var require_stream_readable = __commonJS({
       var state = this._readableState;
       var paused = false;
       stream2.on("end", function() {
-        debug2("wrapped end");
+        debug3("wrapped end");
         if (state.decoder && !state.ended) {
           var chunk = state.decoder.end();
           if (chunk && chunk.length)
@@ -22716,7 +22716,7 @@ var require_stream_readable = __commonJS({
         _this.push(null);
       });
       stream2.on("data", function(chunk) {
-        debug2("wrapped data");
+        debug3("wrapped data");
         if (state.decoder)
           chunk = state.decoder.write(chunk);
         if (state.objectMode && (chunk === null || chunk === void 0))
@@ -22742,7 +22742,7 @@ var require_stream_readable = __commonJS({
         stream2.on(kProxyEvents[n], this.emit.bind(this, kProxyEvents[n]));
       }
       this._read = function(n2) {
-        debug2("wrapped _read", n2);
+        debug3("wrapped _read", n2);
         if (paused) {
           paused = false;
           stream2.resume();
@@ -23403,14 +23403,14 @@ var require_lib3 = __commonJS({
       }
       return self2;
     };
-    handlers.reject = function(self2, error) {
+    handlers.reject = function(self2, error2) {
       self2.state = REJECTED;
-      self2.outcome = error;
+      self2.outcome = error2;
       if (!process.browser) {
         if (self2.handled === UNHANDLED) {
           immediate(function() {
             if (self2.handled === UNHANDLED) {
-              process.emit("unhandledRejection", error, self2);
+              process.emit("unhandledRejection", error2, self2);
             }
           });
         }
@@ -23418,7 +23418,7 @@ var require_lib3 = __commonJS({
       var i = -1;
       var len = self2.queue.length;
       while (++i < len) {
-        self2.queue[i].callRejected(error);
+        self2.queue[i].callRejected(error2);
       }
       return self2;
     };
@@ -23497,10 +23497,10 @@ var require_lib3 = __commonJS({
       }
       return promise;
       function allResolver(value, i2) {
-        self2.resolve(value).then(resolveFromAll, function(error) {
+        self2.resolve(value).then(resolveFromAll, function(error2) {
           if (!called) {
             called = true;
-            handlers.reject(promise, error);
+            handlers.reject(promise, error2);
           }
         });
         function resolveFromAll(outValue) {
@@ -23535,10 +23535,10 @@ var require_lib3 = __commonJS({
             called = true;
             handlers.resolve(promise, response);
           }
-        }, function(error) {
+        }, function(error2) {
           if (!called) {
             called = true;
-            handlers.reject(promise, error);
+            handlers.reject(promise, error2);
           }
         });
       }
@@ -39713,17 +39713,17 @@ var require_iterate = __commonJS({
     module2.exports = iterate;
     function iterate(list, iterator, state, callback) {
       var key = state["keyedList"] ? state["keyedList"][state.index] : state.index;
-      state.jobs[key] = runJob(iterator, key, list[key], function(error, output) {
+      state.jobs[key] = runJob(iterator, key, list[key], function(error2, output) {
         if (!(key in state.jobs)) {
           return;
         }
         delete state.jobs[key];
-        if (error) {
+        if (error2) {
           abort(state);
         } else {
           state.results[key] = output;
         }
-        callback(error, state.results);
+        callback(error2, state.results);
       });
     }
     function runJob(iterator, key, item, callback) {
@@ -39787,9 +39787,9 @@ var require_parallel = __commonJS({
     function parallel(list, iterator, callback) {
       var state = initState(list);
       while (state.index < (state["keyedList"] || list).length) {
-        iterate(list, iterator, state, function(error, result) {
-          if (error) {
-            callback(error, result);
+        iterate(list, iterator, state, function(error2, result) {
+          if (error2) {
+            callback(error2, result);
             return;
           }
           if (Object.keys(state.jobs).length === 0) {
@@ -39815,9 +39815,9 @@ var require_serialOrdered = __commonJS({
     module2.exports.descending = descending;
     function serialOrdered(list, iterator, sortMethod, callback) {
       var state = initState(list, sortMethod);
-      iterate(list, iterator, state, function iteratorHandler(error, result) {
-        if (error) {
-          callback(error, result);
+      iterate(list, iterator, state, function iteratorHandler(error2, result) {
+        if (error2) {
+          callback(error2, result);
           return;
         }
         state.index++;
@@ -40162,10 +40162,10 @@ var require_form_data = __commonJS({
         this.pipe(request);
         if (cb) {
           var onResponse;
-          var callback = function(error, responce) {
+          var callback = function(error2, responce) {
             request.removeListener("error", callback);
             request.removeListener("response", onResponse);
-            return cb.call(this, error, responce);
+            return cb.call(this, error2, responce);
           };
           onResponse = callback.bind(this, null);
           request.on("error", callback);
@@ -40260,8 +40260,8 @@ var require_add = __commonJS({
       }
       if (kind === "error") {
         hook = function(method, options) {
-          return Promise.resolve().then(method.bind(null, options)).catch(function(error) {
-            return orig(error, options);
+          return Promise.resolve().then(method.bind(null, options)).catch(function(error2) {
+            return orig(error2, options);
           });
         };
       }
@@ -40988,7 +40988,7 @@ var require_dist_node5 = __commonJS({
         }
         if (status >= 400) {
           const data = await getResponseData(response);
-          const error = new import_request_error.RequestError(toErrorMessage(data), status, {
+          const error2 = new import_request_error.RequestError(toErrorMessage(data), status, {
             response: {
               url,
               status,
@@ -40997,7 +40997,7 @@ var require_dist_node5 = __commonJS({
             },
             request: requestOptions
           });
-          throw error;
+          throw error2;
         }
         return parseSuccessResponseBody ? await getResponseData(response) : response.body;
       }).then((data) => {
@@ -41007,12 +41007,12 @@ var require_dist_node5 = __commonJS({
           headers,
           data
         };
-      }).catch((error) => {
-        if (error instanceof import_request_error.RequestError)
-          throw error;
-        else if (error.name === "AbortError")
-          throw error;
-        throw new import_request_error.RequestError(error.message, 500, {
+      }).catch((error2) => {
+        if (error2 instanceof import_request_error.RequestError)
+          throw error2;
+        else if (error2.name === "AbortError")
+          throw error2;
+        throw new import_request_error.RequestError(error2.message, 500, {
           request: requestOptions
         });
       });
@@ -41567,9 +41567,9 @@ var require_dist_node10 = __commonJS({
                 /<([^>]+)>;\s*rel="next"/
               ) || [])[1];
               return { value: normalizedResponse };
-            } catch (error) {
-              if (error.status !== 409)
-                throw error;
+            } catch (error2) {
+              if (error2.status !== 409)
+                throw error2;
               url = "";
               return {
                 value: {
@@ -46936,7 +46936,7 @@ Content-Type: ${value.type || "application/octet-stream"}\r
         throw new TypeError("Body is unusable");
       }
       const promise = createDeferredPromise();
-      const errorSteps = (error) => promise.reject(error);
+      const errorSteps = (error2) => promise.reject(error2);
       const successSteps = (data) => {
         try {
           promise.resolve(convertBytesToJSValue(data));
@@ -47219,16 +47219,16 @@ var require_request3 = __commonJS({
           this.onError(err);
         }
       }
-      onError(error) {
+      onError(error2) {
         this.onFinally();
         if (channels.error.hasSubscribers) {
-          channels.error.publish({ request: this, error });
+          channels.error.publish({ request: this, error: error2 });
         }
         if (this.aborted) {
           return;
         }
         this.aborted = true;
-        return this[kHandler].onError(error);
+        return this[kHandler].onError(error2);
       }
       onFinally() {
         if (this.errorHandler) {
@@ -48104,8 +48104,8 @@ var require_RedirectHandler2 = __commonJS({
       onUpgrade(statusCode, headers, socket) {
         this.handler.onUpgrade(statusCode, headers, socket);
       }
-      onError(error) {
-        this.handler.onError(error);
+      onError(error2) {
+        this.handler.onError(error2);
       }
       onHeaders(statusCode, headers, resume, statusText) {
         this.location = this.history.length >= this.maxRedirections || util2.isDisturbed(this.opts.body) ? null : parseLocation(statusCode, headers);
@@ -51855,13 +51855,13 @@ var require_mock_utils2 = __commonJS({
       if (mockDispatch2.data.callback) {
         mockDispatch2.data = { ...mockDispatch2.data, ...mockDispatch2.data.callback(opts) };
       }
-      const { data: { statusCode, data, headers, trailers, error }, delay, persist } = mockDispatch2;
+      const { data: { statusCode, data, headers, trailers, error: error2 }, delay, persist } = mockDispatch2;
       const { timesInvoked, times } = mockDispatch2;
       mockDispatch2.consumed = !persist && timesInvoked >= times;
       mockDispatch2.pending = timesInvoked < times;
-      if (error !== null) {
+      if (error2 !== null) {
         deleteMockDispatch(this[kDispatches], key);
-        handler.onError(error);
+        handler.onError(error2);
         return true;
       }
       if (typeof delay === "number" && delay > 0) {
@@ -51899,19 +51899,19 @@ var require_mock_utils2 = __commonJS({
         if (agent.isMockActive) {
           try {
             mockDispatch.call(this, opts, handler);
-          } catch (error) {
-            if (error instanceof MockNotMatchedError) {
+          } catch (error2) {
+            if (error2 instanceof MockNotMatchedError) {
               const netConnect = agent[kGetNetConnect]();
               if (netConnect === false) {
-                throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect disabled)`);
+                throw new MockNotMatchedError(`${error2.message}: subsequent request to origin ${origin} was not allowed (net.connect disabled)`);
               }
               if (checkNetConnect(netConnect, origin)) {
                 originalDispatch.call(this, opts, handler);
               } else {
-                throw new MockNotMatchedError(`${error.message}: subsequent request to origin ${origin} was not allowed (net.connect is not enabled for this origin)`);
+                throw new MockNotMatchedError(`${error2.message}: subsequent request to origin ${origin} was not allowed (net.connect is not enabled for this origin)`);
               }
             } else {
-              throw error;
+              throw error2;
             }
           }
         } else {
@@ -52074,11 +52074,11 @@ var require_mock_interceptor2 = __commonJS({
       /**
        * Mock an undici request with a defined error.
        */
-      replyWithError(error) {
-        if (typeof error === "undefined") {
+      replyWithError(error2) {
+        if (typeof error2 === "undefined") {
           throw new InvalidArgumentError("error must be defined");
         }
-        const newMockDispatch = addMockDispatch(this[kDispatches], this[kDispatchKey], { error });
+        const newMockDispatch = addMockDispatch(this[kDispatches], this[kDispatchKey], { error: error2 });
         return new MockScope(newMockDispatch);
       }
       /**
@@ -54417,17 +54417,17 @@ var require_fetch2 = __commonJS({
         this.emit("terminated", reason);
       }
       // https://fetch.spec.whatwg.org/#fetch-controller-abort
-      abort(error) {
+      abort(error2) {
         if (this.state !== "ongoing") {
           return;
         }
         this.state = "aborted";
-        if (!error) {
-          error = new DOMException("The operation was aborted.", "AbortError");
+        if (!error2) {
+          error2 = new DOMException("The operation was aborted.", "AbortError");
         }
-        this.serializedAbortReason = error;
-        this.connection?.destroy(error);
-        this.emit("terminated", error);
+        this.serializedAbortReason = error2;
+        this.connection?.destroy(error2);
+        this.emit("terminated", error2);
       }
     };
     function fetch(input, init = {}) {
@@ -54532,13 +54532,13 @@ var require_fetch2 = __commonJS({
         performance.markResourceTiming(timingInfo, originalURL.href, initiatorType, globalThis2, cacheState);
       }
     }
-    function abortFetch(p, request, responseObject, error) {
-      if (!error) {
-        error = new DOMException("The operation was aborted.", "AbortError");
+    function abortFetch(p, request, responseObject, error2) {
+      if (!error2) {
+        error2 = new DOMException("The operation was aborted.", "AbortError");
       }
-      p.reject(error);
+      p.reject(error2);
       if (request.body != null && isReadable(request.body?.stream)) {
-        request.body.stream.cancel(error).catch((err) => {
+        request.body.stream.cancel(error2).catch((err) => {
           if (err.code === "ERR_INVALID_STATE") {
             return;
           }
@@ -54550,7 +54550,7 @@ var require_fetch2 = __commonJS({
       }
       const response = responseObject[kState];
       if (response.body != null && isReadable(response.body?.stream)) {
-        response.body.stream.cancel(error).catch((err) => {
+        response.body.stream.cancel(error2).catch((err) => {
           if (err.code === "ERR_INVALID_STATE") {
             return;
           }
@@ -55377,13 +55377,13 @@ var require_fetch2 = __commonJS({
               fetchParams.controller.ended = true;
               this.body.push(null);
             },
-            onError(error) {
+            onError(error2) {
               if (this.abort) {
                 fetchParams.controller.off("terminated", this.abort);
               }
-              this.body?.destroy(error);
-              fetchParams.controller.terminate(error);
-              reject(error);
+              this.body?.destroy(error2);
+              fetchParams.controller.terminate(error2);
+              reject(error2);
             },
             onUpgrade(status, headersList, socket) {
               if (status !== 101) {
@@ -55848,8 +55848,8 @@ var require_util12 = __commonJS({
                   }
                   fr[kResult] = result;
                   fireAProgressEvent("load", fr);
-                } catch (error) {
-                  fr[kError] = error;
+                } catch (error2) {
+                  fr[kError] = error2;
                   fireAProgressEvent("error", fr);
                 }
                 if (fr[kState] !== "loading") {
@@ -55858,13 +55858,13 @@ var require_util12 = __commonJS({
               });
               break;
             }
-          } catch (error) {
+          } catch (error2) {
             if (fr[kAborted]) {
               return;
             }
             queueMicrotask(() => {
               fr[kState] = "done";
-              fr[kError] = error;
+              fr[kError] = error2;
               fireAProgressEvent("error", fr);
               if (fr[kState] !== "loading") {
                 fireAProgressEvent("loadend", fr);
@@ -57880,11 +57880,11 @@ var require_connection2 = __commonJS({
         });
       }
     }
-    function onSocketError(error) {
+    function onSocketError(error2) {
       const { ws } = this;
       ws[kReadyState] = states.CLOSING;
       if (channels.socketError.hasSubscribers) {
-        channels.socketError.publish(error);
+        channels.socketError.publish(error2);
       }
       this.destroy();
     }
@@ -58754,7 +58754,7 @@ var require_dist_node12 = __commonJS({
       getProxyAgent: () => getProxyAgent
     });
     module2.exports = __toCommonJS2(dist_src_exports);
-    var import_core3 = require_dist_node8();
+    var import_core4 = require_dist_node8();
     var import_auth_action = require_dist_node9();
     var import_plugin_paginate_rest = require_dist_node10();
     var import_plugin_rest_endpoint_methods = require_dist_node11();
@@ -58782,7 +58782,7 @@ var require_dist_node12 = __commonJS({
         ...opts
       });
     };
-    var Octokit2 = import_core3.Octokit.plugin(
+    var Octokit2 = import_core4.Octokit.plugin(
       import_plugin_paginate_rest.paginateRest,
       import_plugin_rest_endpoint_methods.legacyRestEndpointMethods
     ).defaults(function buildDefaults(options) {
@@ -58981,8 +58981,8 @@ var require_light = __commonJS({
                 } else {
                   return returned;
                 }
-              } catch (error) {
-                e2 = error;
+              } catch (error2) {
+                e2 = error2;
                 {
                   this.trigger("error", e2);
                 }
@@ -58992,8 +58992,8 @@ var require_light = __commonJS({
             return (await Promise.all(promises)).find(function(x) {
               return x != null;
             });
-          } catch (error) {
-            e = error;
+          } catch (error2) {
+            e = error2;
             {
               this.trigger("error", e);
             }
@@ -59105,10 +59105,10 @@ var require_light = __commonJS({
         _randomIndex() {
           return Math.random().toString(36).slice(2);
         }
-        doDrop({ error, message = "This job has been dropped by Bottleneck" } = {}) {
+        doDrop({ error: error2, message = "This job has been dropped by Bottleneck" } = {}) {
           if (this._states.remove(this.options.id)) {
             if (this.rejectOnDrop) {
-              this._reject(error != null ? error : new BottleneckError$1(message));
+              this._reject(error2 != null ? error2 : new BottleneckError$1(message));
             }
             this.Events.trigger("dropped", { args: this.args, options: this.options, task: this.task, promise: this.promise });
             return true;
@@ -59142,7 +59142,7 @@ var require_light = __commonJS({
           return this.Events.trigger("scheduled", { args: this.args, options: this.options });
         }
         async doExecute(chained, clearGlobalState, run2, free) {
-          var error, eventInfo, passed;
+          var error2, eventInfo, passed;
           if (this.retryCount === 0) {
             this._assertStatus("RUNNING");
             this._states.next(this.options.id);
@@ -59160,24 +59160,24 @@ var require_light = __commonJS({
               return this._resolve(passed);
             }
           } catch (error1) {
-            error = error1;
-            return this._onFailure(error, eventInfo, clearGlobalState, run2, free);
+            error2 = error1;
+            return this._onFailure(error2, eventInfo, clearGlobalState, run2, free);
           }
         }
         doExpire(clearGlobalState, run2, free) {
-          var error, eventInfo;
+          var error2, eventInfo;
           if (this._states.jobStatus(this.options.id === "RUNNING")) {
             this._states.next(this.options.id);
           }
           this._assertStatus("EXECUTING");
           eventInfo = { args: this.args, options: this.options, retryCount: this.retryCount };
-          error = new BottleneckError$1(`This job timed out after ${this.options.expiration} ms.`);
-          return this._onFailure(error, eventInfo, clearGlobalState, run2, free);
+          error2 = new BottleneckError$1(`This job timed out after ${this.options.expiration} ms.`);
+          return this._onFailure(error2, eventInfo, clearGlobalState, run2, free);
         }
-        async _onFailure(error, eventInfo, clearGlobalState, run2, free) {
+        async _onFailure(error2, eventInfo, clearGlobalState, run2, free) {
           var retry2, retryAfter;
           if (clearGlobalState()) {
-            retry2 = await this.Events.trigger("failed", error, eventInfo);
+            retry2 = await this.Events.trigger("failed", error2, eventInfo);
             if (retry2 != null) {
               retryAfter = ~~retry2;
               this.Events.trigger("retry", `Retrying ${this.options.id} after ${retryAfter} ms`, eventInfo);
@@ -59187,7 +59187,7 @@ var require_light = __commonJS({
               this.doDone(eventInfo);
               await free(this.options, eventInfo);
               this._assertStatus("DONE");
-              return this._reject(error);
+              return this._reject(error2);
             }
           }
         }
@@ -59466,7 +59466,7 @@ var require_light = __commonJS({
           return this._queue.length === 0;
         }
         async _tryToRun() {
-          var args, cb, error, reject, resolve, returned, task;
+          var args, cb, error2, reject, resolve, returned, task;
           if (this._running < 1 && this._queue.length > 0) {
             this._running++;
             ({ task, args, resolve, reject } = this._queue.shift());
@@ -59477,9 +59477,9 @@ var require_light = __commonJS({
                   return resolve(returned);
                 };
               } catch (error1) {
-                error = error1;
+                error2 = error1;
                 return function() {
-                  return reject(error);
+                  return reject(error2);
                 };
               }
             }();
@@ -59613,8 +59613,8 @@ var require_light = __commonJS({
                   } else {
                     results.push(void 0);
                   }
-                } catch (error) {
-                  e = error;
+                } catch (error2) {
+                  e = error2;
                   results.push(v.Events.trigger("error", e));
                 }
               }
@@ -59947,14 +59947,14 @@ var require_light = __commonJS({
             return done;
           }
           async _addToQueue(job) {
-            var args, blocked, error, options, reachedHWM, shifted, strategy;
+            var args, blocked, error2, options, reachedHWM, shifted, strategy;
             ({ args, options } = job);
             try {
               ({ reachedHWM, blocked, strategy } = await this._store.__submit__(this.queued(), options.weight));
             } catch (error1) {
-              error = error1;
-              this.Events.trigger("debug", `Could not queue ${options.id}`, { args, options, error });
-              job.doDrop({ error });
+              error2 = error1;
+              this.Events.trigger("debug", `Could not queue ${options.id}`, { args, options, error: error2 });
+              job.doDrop({ error: error2 });
               return false;
             }
             if (blocked) {
@@ -60157,25 +60157,25 @@ var require_dist_node13 = __commonJS({
       retry: () => retry2
     });
     module2.exports = __toCommonJS2(dist_src_exports);
-    var import_core3 = require_dist_node8();
-    async function errorRequest(state, octokit, error, options) {
-      if (!error.request || !error.request.request) {
-        throw error;
+    var import_core4 = require_dist_node8();
+    async function errorRequest(state, octokit, error2, options) {
+      if (!error2.request || !error2.request.request) {
+        throw error2;
       }
-      if (error.status >= 400 && !state.doNotRetry.includes(error.status)) {
+      if (error2.status >= 400 && !state.doNotRetry.includes(error2.status)) {
         const retries = options.request.retries != null ? options.request.retries : state.retries;
         const retryAfter = Math.pow((options.request.retryCount || 0) + 1, 2);
-        throw octokit.retry.retryRequest(error, retries, retryAfter);
+        throw octokit.retry.retryRequest(error2, retries, retryAfter);
       }
-      throw error;
+      throw error2;
     }
     var import_light = __toESM2(require_light());
     var import_request_error = require_dist_node4();
     async function wrapRequest(state, octokit, request, options) {
       const limiter = new import_light.default();
-      limiter.on("failed", function(error, info2) {
-        const maxRetries = ~~error.request.request.retries;
-        const after = ~~error.request.request.retryAfter;
+      limiter.on("failed", function(error2, info2) {
+        const maxRetries = ~~error2.request.request.retries;
+        const after = ~~error2.request.request.retryAfter;
         options.request.retryCount = info2.retryCount + 1;
         if (maxRetries > info2.retryCount) {
           return after * state.retryAfterBaseValue;
@@ -60191,11 +60191,11 @@ var require_dist_node13 = __commonJS({
       if (response.data && response.data.errors && /Something went wrong while executing your query/.test(
         response.data.errors[0].message
       )) {
-        const error = new import_request_error.RequestError(response.data.errors[0].message, 500, {
+        const error2 = new import_request_error.RequestError(response.data.errors[0].message, 500, {
           request: options,
           response
         });
-        return errorRequest(state, octokit, error, options);
+        return errorRequest(state, octokit, error2, options);
       }
       return response;
     }
@@ -60216,12 +60216,12 @@ var require_dist_node13 = __commonJS({
       }
       return {
         retry: {
-          retryRequest: (error, retries, retryAfter) => {
-            error.request.request = Object.assign({}, error.request.request, {
+          retryRequest: (error2, retries, retryAfter) => {
+            error2.request.request = Object.assign({}, error2.request.request, {
               retries,
               retryAfter
             });
-            return error;
+            return error2;
           }
         }
       };
@@ -60267,7 +60267,7 @@ var require_dist_node14 = __commonJS({
     });
     module2.exports = __toCommonJS2(dist_src_exports);
     var import_light = __toESM2(require_light());
-    var import_core3 = require_dist_node8();
+    var import_core4 = require_dist_node8();
     var VERSION = "8.1.3";
     var noop = () => Promise.resolve();
     function wrapRequest(state, request, options) {
@@ -60299,12 +60299,12 @@ var require_dist_node14 = __commonJS({
       );
       if (isGraphQL) {
         const res = await req;
-        if (res.data.errors != null && res.data.errors.some((error) => error.type === "RATE_LIMITED")) {
-          const error = Object.assign(new Error("GraphQL Rate Limit Exceeded"), {
+        if (res.data.errors != null && res.data.errors.some((error2) => error2.type === "RATE_LIMITED")) {
+          const error2 = Object.assign(new Error("GraphQL Rate Limit Exceeded"), {
             response: res,
             data: res.data
           });
-          throw error;
+          throw error2;
         }
       }
       return req;
@@ -60412,19 +60412,19 @@ var require_dist_node14 = __commonJS({
         "error",
         (e) => octokit.log.warn("Error in throttling-plugin limit handler", e)
       );
-      state.retryLimiter.on("failed", async function(error, info2) {
+      state.retryLimiter.on("failed", async function(error2, info2) {
         const [state2, request, options] = info2.args;
         const { pathname } = new URL(options.url, "http://github.test");
-        const shouldRetryGraphQL = pathname.startsWith("/graphql") && error.status !== 401;
-        if (!(shouldRetryGraphQL || error.status === 403)) {
+        const shouldRetryGraphQL = pathname.startsWith("/graphql") && error2.status !== 401;
+        if (!(shouldRetryGraphQL || error2.status === 403)) {
           return;
         }
         const retryCount = ~~request.retryCount;
         request.retryCount = retryCount;
         options.request.retryCount = retryCount;
         const { wantRetry, retryAfter = 0 } = await async function() {
-          if (/\bsecondary rate\b/i.test(error.message)) {
-            const retryAfter2 = Number(error.response.headers["retry-after"]) || state2.fallbackSecondaryRateRetryAfter;
+          if (/\bsecondary rate\b/i.test(error2.message)) {
+            const retryAfter2 = Number(error2.response.headers["retry-after"]) || state2.fallbackSecondaryRateRetryAfter;
             const wantRetry2 = await emitter.trigger(
               "secondary-limit",
               retryAfter2,
@@ -60434,11 +60434,11 @@ var require_dist_node14 = __commonJS({
             );
             return { wantRetry: wantRetry2, retryAfter: retryAfter2 };
           }
-          if (error.response.headers != null && error.response.headers["x-ratelimit-remaining"] === "0" || (error.response.data?.errors ?? []).some(
-            (error2) => error2.type === "RATE_LIMITED"
+          if (error2.response.headers != null && error2.response.headers["x-ratelimit-remaining"] === "0" || (error2.response.data?.errors ?? []).some(
+            (error22) => error22.type === "RATE_LIMITED"
           )) {
             const rateLimitReset = new Date(
-              ~~error.response.headers["x-ratelimit-reset"] * 1e3
+              ~~error2.response.headers["x-ratelimit-reset"] * 1e3
             ).getTime();
             const retryAfter2 = Math.max(
               // Add one second so we retry _after_ the reset time
@@ -60910,9 +60910,9 @@ var require_codegen = __commonJS({
       }
     };
     var Throw = class extends Node {
-      constructor(error) {
+      constructor(error2) {
         super();
-        this.error = error;
+        this.error = error2;
       }
       render({ _n }) {
         return `throw ${this.error};` + _n;
@@ -61149,9 +61149,9 @@ var require_codegen = __commonJS({
       }
     };
     var Catch = class extends BlockNode {
-      constructor(error) {
+      constructor(error2) {
         super();
-        this.error = error;
+        this.error = error2;
       }
       render(opts) {
         return `catch(${this.error})` + super.render(opts);
@@ -61342,9 +61342,9 @@ var require_codegen = __commonJS({
         this._blockNode(node);
         this.code(tryBody);
         if (catchCode) {
-          const error = this.name("e");
-          this._currNode = node.catch = new Catch(error);
-          catchCode(error);
+          const error2 = this.name("e");
+          this._currNode = node.catch = new Catch(error2);
+          catchCode(error2);
         }
         if (finallyCode) {
           this._currNode = node.finally = new Finally();
@@ -61353,8 +61353,8 @@ var require_codegen = __commonJS({
         return this._endBlockNode(Catch, Finally);
       }
       // `throw` statement
-      throw(error) {
-        return this._leafNode(new Throw(error));
+      throw(error2) {
+        return this._leafNode(new Throw(error2));
       }
       // start self-balancing block
       block(body, nodeCount) {
@@ -61704,10 +61704,10 @@ var require_errors3 = __commonJS({
     exports2.keyword$DataError = {
       message: ({ keyword, schemaType }) => schemaType ? (0, codegen_1.str)`"${keyword}" keyword must be ${schemaType} ($data)` : (0, codegen_1.str)`"${keyword}" keyword is invalid ($data)`
     };
-    function reportError(cxt, error = exports2.keywordError, errorPaths, overrideAllErrors) {
+    function reportError(cxt, error2 = exports2.keywordError, errorPaths, overrideAllErrors) {
       const { it } = cxt;
       const { gen, compositeRule, allErrors } = it;
-      const errObj = errorObjectCode(cxt, error, errorPaths);
+      const errObj = errorObjectCode(cxt, error2, errorPaths);
       if (overrideAllErrors !== null && overrideAllErrors !== void 0 ? overrideAllErrors : compositeRule || allErrors) {
         addError(gen, errObj);
       } else {
@@ -61715,10 +61715,10 @@ var require_errors3 = __commonJS({
       }
     }
     exports2.reportError = reportError;
-    function reportExtraError(cxt, error = exports2.keywordError, errorPaths) {
+    function reportExtraError(cxt, error2 = exports2.keywordError, errorPaths) {
       const { it } = cxt;
       const { gen, compositeRule, allErrors } = it;
-      const errObj = errorObjectCode(cxt, error, errorPaths);
+      const errObj = errorObjectCode(cxt, error2, errorPaths);
       addError(gen, errObj);
       if (!(compositeRule || allErrors)) {
         returnErrors(it, names_1.default.vErrors);
@@ -61768,19 +61768,19 @@ var require_errors3 = __commonJS({
       schema: new codegen_1.Name("schema"),
       parentSchema: new codegen_1.Name("parentSchema")
     };
-    function errorObjectCode(cxt, error, errorPaths) {
+    function errorObjectCode(cxt, error2, errorPaths) {
       const { createErrors } = cxt.it;
       if (createErrors === false)
         return (0, codegen_1._)`{}`;
-      return errorObject(cxt, error, errorPaths);
+      return errorObject(cxt, error2, errorPaths);
     }
-    function errorObject(cxt, error, errorPaths = {}) {
+    function errorObject(cxt, error2, errorPaths = {}) {
       const { gen, it } = cxt;
       const keyValues = [
         errorInstancePath(it, errorPaths),
         errorSchemaPath(cxt, errorPaths)
       ];
-      extraErrorProps(cxt, error, keyValues);
+      extraErrorProps(cxt, error2, keyValues);
       return gen.object(...keyValues);
     }
     function errorInstancePath({ errorPath }, { instancePath }) {
@@ -65371,7 +65371,7 @@ var require_limitNumber = __commonJS({
       exclusiveMaximum: { okStr: "<", ok: ops.LT, fail: ops.GTE },
       exclusiveMinimum: { okStr: ">", ok: ops.GT, fail: ops.LTE }
     };
-    var error = {
+    var error2 = {
       message: ({ keyword, schemaCode }) => (0, codegen_1.str)`must be ${KWDs[keyword].okStr} ${schemaCode}`,
       params: ({ keyword, schemaCode }) => (0, codegen_1._)`{comparison: ${KWDs[keyword].okStr}, limit: ${schemaCode}}`
     };
@@ -65380,7 +65380,7 @@ var require_limitNumber = __commonJS({
       type: "number",
       schemaType: "number",
       $data: true,
-      error,
+      error: error2,
       code(cxt) {
         const { keyword, data, schemaCode } = cxt;
         cxt.fail$data((0, codegen_1._)`${data} ${KWDs[keyword].fail} ${schemaCode} || isNaN(${data})`);
@@ -65396,7 +65396,7 @@ var require_multipleOf = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
-    var error = {
+    var error2 = {
       message: ({ schemaCode }) => (0, codegen_1.str)`must be multiple of ${schemaCode}`,
       params: ({ schemaCode }) => (0, codegen_1._)`{multipleOf: ${schemaCode}}`
     };
@@ -65405,7 +65405,7 @@ var require_multipleOf = __commonJS({
       type: "number",
       schemaType: "number",
       $data: true,
-      error,
+      error: error2,
       code(cxt) {
         const { gen, data, schemaCode, it } = cxt;
         const prec = it.opts.multipleOfPrecision;
@@ -65452,7 +65452,7 @@ var require_limitLength = __commonJS({
     var codegen_1 = require_codegen();
     var util_1 = require_util16();
     var ucs2length_1 = require_ucs2length();
-    var error = {
+    var error2 = {
       message({ keyword, schemaCode }) {
         const comp = keyword === "maxLength" ? "more" : "fewer";
         return (0, codegen_1.str)`must NOT have ${comp} than ${schemaCode} characters`;
@@ -65464,7 +65464,7 @@ var require_limitLength = __commonJS({
       type: "string",
       schemaType: "number",
       $data: true,
-      error,
+      error: error2,
       code(cxt) {
         const { keyword, data, schemaCode, it } = cxt;
         const op = keyword === "maxLength" ? codegen_1.operators.GT : codegen_1.operators.LT;
@@ -65483,7 +65483,7 @@ var require_pattern = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     var code_1 = require_code2();
     var codegen_1 = require_codegen();
-    var error = {
+    var error2 = {
       message: ({ schemaCode }) => (0, codegen_1.str)`must match pattern "${schemaCode}"`,
       params: ({ schemaCode }) => (0, codegen_1._)`{pattern: ${schemaCode}}`
     };
@@ -65492,7 +65492,7 @@ var require_pattern = __commonJS({
       type: "string",
       schemaType: "string",
       $data: true,
-      error,
+      error: error2,
       code(cxt) {
         const { data, $data, schema, schemaCode, it } = cxt;
         const u = it.opts.unicodeRegExp ? "u" : "";
@@ -65510,7 +65510,7 @@ var require_limitProperties = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
-    var error = {
+    var error2 = {
       message({ keyword, schemaCode }) {
         const comp = keyword === "maxProperties" ? "more" : "fewer";
         return (0, codegen_1.str)`must NOT have ${comp} than ${schemaCode} properties`;
@@ -65522,7 +65522,7 @@ var require_limitProperties = __commonJS({
       type: "object",
       schemaType: "number",
       $data: true,
-      error,
+      error: error2,
       code(cxt) {
         const { keyword, data, schemaCode } = cxt;
         const op = keyword === "maxProperties" ? codegen_1.operators.GT : codegen_1.operators.LT;
@@ -65541,7 +65541,7 @@ var require_required = __commonJS({
     var code_1 = require_code2();
     var codegen_1 = require_codegen();
     var util_1 = require_util16();
-    var error = {
+    var error2 = {
       message: ({ params: { missingProperty } }) => (0, codegen_1.str)`must have required property '${missingProperty}'`,
       params: ({ params: { missingProperty } }) => (0, codegen_1._)`{missingProperty: ${missingProperty}}`
     };
@@ -65550,7 +65550,7 @@ var require_required = __commonJS({
       type: "object",
       schemaType: "array",
       $data: true,
-      error,
+      error: error2,
       code(cxt) {
         const { gen, schema, schemaCode, data, $data, it } = cxt;
         const { opts } = it;
@@ -65621,7 +65621,7 @@ var require_limitItems = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
-    var error = {
+    var error2 = {
       message({ keyword, schemaCode }) {
         const comp = keyword === "maxItems" ? "more" : "fewer";
         return (0, codegen_1.str)`must NOT have ${comp} than ${schemaCode} items`;
@@ -65633,7 +65633,7 @@ var require_limitItems = __commonJS({
       type: "array",
       schemaType: "number",
       $data: true,
-      error,
+      error: error2,
       code(cxt) {
         const { keyword, data, schemaCode } = cxt;
         const op = keyword === "maxItems" ? codegen_1.operators.GT : codegen_1.operators.LT;
@@ -65664,7 +65664,7 @@ var require_uniqueItems = __commonJS({
     var codegen_1 = require_codegen();
     var util_1 = require_util16();
     var equal_1 = require_equal();
-    var error = {
+    var error2 = {
       message: ({ params: { i, j } }) => (0, codegen_1.str)`must NOT have duplicate items (items ## ${j} and ${i} are identical)`,
       params: ({ params: { i, j } }) => (0, codegen_1._)`{i: ${i}, j: ${j}}`
     };
@@ -65673,7 +65673,7 @@ var require_uniqueItems = __commonJS({
       type: "array",
       schemaType: "boolean",
       $data: true,
-      error,
+      error: error2,
       code(cxt) {
         const { gen, data, $data, schema, parentSchema, schemaCode, it } = cxt;
         if (!$data && !schema)
@@ -65730,14 +65730,14 @@ var require_const = __commonJS({
     var codegen_1 = require_codegen();
     var util_1 = require_util16();
     var equal_1 = require_equal();
-    var error = {
+    var error2 = {
       message: "must be equal to constant",
       params: ({ schemaCode }) => (0, codegen_1._)`{allowedValue: ${schemaCode}}`
     };
     var def = {
       keyword: "const",
       $data: true,
-      error,
+      error: error2,
       code(cxt) {
         const { gen, data, $data, schemaCode, schema } = cxt;
         if ($data || schema && typeof schema == "object") {
@@ -65759,7 +65759,7 @@ var require_enum = __commonJS({
     var codegen_1 = require_codegen();
     var util_1 = require_util16();
     var equal_1 = require_equal();
-    var error = {
+    var error2 = {
       message: "must be equal to one of the allowed values",
       params: ({ schemaCode }) => (0, codegen_1._)`{allowedValues: ${schemaCode}}`
     };
@@ -65767,7 +65767,7 @@ var require_enum = __commonJS({
       keyword: "enum",
       schemaType: "array",
       $data: true,
-      error,
+      error: error2,
       code(cxt) {
         const { gen, data, $data, schema, schemaCode, it } = cxt;
         if (!$data && schema.length === 0)
@@ -65846,7 +65846,7 @@ var require_additionalItems = __commonJS({
     exports2.validateAdditionalItems = void 0;
     var codegen_1 = require_codegen();
     var util_1 = require_util16();
-    var error = {
+    var error2 = {
       message: ({ params: { len } }) => (0, codegen_1.str)`must NOT have more than ${len} items`,
       params: ({ params: { len } }) => (0, codegen_1._)`{limit: ${len}}`
     };
@@ -65855,7 +65855,7 @@ var require_additionalItems = __commonJS({
       type: "array",
       schemaType: ["boolean", "object"],
       before: "uniqueItems",
-      error,
+      error: error2,
       code(cxt) {
         const { parentSchema, it } = cxt;
         const { items } = parentSchema;
@@ -65974,7 +65974,7 @@ var require_items2020 = __commonJS({
     var util_1 = require_util16();
     var code_1 = require_code2();
     var additionalItems_1 = require_additionalItems();
-    var error = {
+    var error2 = {
       message: ({ params: { len } }) => (0, codegen_1.str)`must NOT have more than ${len} items`,
       params: ({ params: { len } }) => (0, codegen_1._)`{limit: ${len}}`
     };
@@ -65983,7 +65983,7 @@ var require_items2020 = __commonJS({
       type: "array",
       schemaType: ["object", "boolean"],
       before: "uniqueItems",
-      error,
+      error: error2,
       code(cxt) {
         const { schema, parentSchema, it } = cxt;
         const { prefixItems } = parentSchema;
@@ -66007,7 +66007,7 @@ var require_contains = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
     var util_1 = require_util16();
-    var error = {
+    var error2 = {
       message: ({ params: { min, max } }) => max === void 0 ? (0, codegen_1.str)`must contain at least ${min} valid item(s)` : (0, codegen_1.str)`must contain at least ${min} and no more than ${max} valid item(s)`,
       params: ({ params: { min, max } }) => max === void 0 ? (0, codegen_1._)`{minContains: ${min}}` : (0, codegen_1._)`{minContains: ${min}, maxContains: ${max}}`
     };
@@ -66017,7 +66017,7 @@ var require_contains = __commonJS({
       schemaType: ["object", "boolean"],
       before: "uniqueItems",
       trackErrors: true,
-      error,
+      error: error2,
       code(cxt) {
         const { gen, schema, parentSchema, data, it } = cxt;
         let min;
@@ -66195,7 +66195,7 @@ var require_propertyNames = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
     var util_1 = require_util16();
-    var error = {
+    var error2 = {
       message: "property name must be valid",
       params: ({ params }) => (0, codegen_1._)`{propertyName: ${params.propertyName}}`
     };
@@ -66203,7 +66203,7 @@ var require_propertyNames = __commonJS({
       keyword: "propertyNames",
       type: "object",
       schemaType: ["object", "boolean"],
-      error,
+      error: error2,
       code(cxt) {
         const { gen, schema, data, it } = cxt;
         if ((0, util_1.alwaysValidSchema)(it, schema))
@@ -66240,7 +66240,7 @@ var require_additionalProperties = __commonJS({
     var codegen_1 = require_codegen();
     var names_1 = require_names();
     var util_1 = require_util16();
-    var error = {
+    var error2 = {
       message: "must NOT have additional properties",
       params: ({ params }) => (0, codegen_1._)`{additionalProperty: ${params.additionalProperty}}`
     };
@@ -66250,7 +66250,7 @@ var require_additionalProperties = __commonJS({
       schemaType: ["boolean", "object"],
       allowUndefined: true,
       trackErrors: true,
-      error,
+      error: error2,
       code(cxt) {
         const { gen, schema, parentSchema, data, errsCount, it } = cxt;
         if (!errsCount)
@@ -66524,7 +66524,7 @@ var require_oneOf = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
     var util_1 = require_util16();
-    var error = {
+    var error2 = {
       message: "must match exactly one schema in oneOf",
       params: ({ params }) => (0, codegen_1._)`{passingSchemas: ${params.passing}}`
     };
@@ -66532,7 +66532,7 @@ var require_oneOf = __commonJS({
       keyword: "oneOf",
       schemaType: "array",
       trackErrors: true,
-      error,
+      error: error2,
       code(cxt) {
         const { gen, schema, parentSchema, it } = cxt;
         if (!Array.isArray(schema))
@@ -66609,7 +66609,7 @@ var require_if = __commonJS({
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
     var util_1 = require_util16();
-    var error = {
+    var error2 = {
       message: ({ params }) => (0, codegen_1.str)`must match "${params.ifClause}" schema`,
       params: ({ params }) => (0, codegen_1._)`{failingKeyword: ${params.ifClause}}`
     };
@@ -66617,7 +66617,7 @@ var require_if = __commonJS({
       keyword: "if",
       schemaType: ["object", "boolean"],
       trackErrors: true,
-      error,
+      error: error2,
       code(cxt) {
         const { gen, parentSchema, it } = cxt;
         if (parentSchema.then === void 0 && parentSchema.else === void 0) {
@@ -66743,7 +66743,7 @@ var require_format = __commonJS({
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
-    var error = {
+    var error2 = {
       message: ({ schemaCode }) => (0, codegen_1.str)`must match format "${schemaCode}"`,
       params: ({ schemaCode }) => (0, codegen_1._)`{format: ${schemaCode}}`
     };
@@ -66752,7 +66752,7 @@ var require_format = __commonJS({
       type: ["number", "string"],
       schemaType: "string",
       $data: true,
-      error,
+      error: error2,
       code(cxt, ruleType) {
         const { gen, data, $data, schema, schemaCode, it } = cxt;
         const { opts, errSchemaPath, schemaEnv, self: self2 } = it;
@@ -66906,7 +66906,7 @@ var require_discriminator = __commonJS({
     var types_1 = require_types();
     var compile_1 = require_compile();
     var util_1 = require_util16();
-    var error = {
+    var error2 = {
       message: ({ params: { discrError, tagName } }) => discrError === types_1.DiscrError.Tag ? `tag "${tagName}" must be string` : `value of tag "${tagName}" must be in oneOf`,
       params: ({ params: { discrError, tag, tagName } }) => (0, codegen_1._)`{error: ${discrError}, tag: ${tagName}, tagValue: ${tag}}`
     };
@@ -66914,7 +66914,7 @@ var require_discriminator = __commonJS({
       keyword: "discriminator",
       type: "object",
       schemaType: "object",
-      error,
+      error: error2,
       code(cxt) {
         const { gen, data, schema, parentSchema, it } = cxt;
         const { oneOf } = parentSchema;
@@ -67560,8 +67560,8 @@ var require_directives = __commonJS({
         if (prefix) {
           try {
             return prefix + decodeURIComponent(suffix);
-          } catch (error) {
-            onError(String(error));
+          } catch (error2) {
+            onError(String(error2));
             return null;
           }
         }
@@ -67664,9 +67664,9 @@ var require_anchors = __commonJS({
             if (typeof ref === "object" && ref.anchor && (identity.isScalar(ref.node) || identity.isCollection(ref.node))) {
               ref.node.anchor = ref.anchor;
             } else {
-              const error = new Error("Failed to resolve repeated object (this should not happen)");
-              error.source = source;
-              throw error;
+              const error2 = new Error("Failed to resolve repeated object (this should not happen)");
+              error2.source = source;
+              throw error2;
             }
           }
         },
@@ -68827,7 +68827,7 @@ ${ctx.indent}`;
 var require_log = __commonJS({
   "node_modules/yaml/dist/log.js"(exports2) {
     "use strict";
-    function debug2(logLevel, ...messages) {
+    function debug3(logLevel, ...messages) {
       if (logLevel === "debug")
         console.log(...messages);
     }
@@ -68839,7 +68839,7 @@ var require_log = __commonJS({
           console.warn(warning2);
       }
     }
-    exports2.debug = debug2;
+    exports2.debug = debug3;
     exports2.warn = warn;
   }
 });
@@ -70833,12 +70833,12 @@ var require_errors4 = __commonJS({
         super("YAMLWarning", pos, code, message);
       }
     };
-    var prettifyError = (src, lc) => (error) => {
-      if (error.pos[0] === -1)
+    var prettifyError = (src, lc) => (error2) => {
+      if (error2.pos[0] === -1)
         return;
-      error.linePos = error.pos.map((pos) => lc.linePos(pos));
-      const { line, col } = error.linePos[0];
-      error.message += ` at line ${line}, column ${col}`;
+      error2.linePos = error2.pos.map((pos) => lc.linePos(pos));
+      const { line, col } = error2.linePos[0];
+      error2.message += ` at line ${line}, column ${col}`;
       let ci = col - 1;
       let lineStr = src.substring(lc.lineStarts[line - 1], lc.lineStarts[line]).replace(/[\n\r]+$/, "");
       if (ci >= 60 && lineStr.length > 80) {
@@ -70856,12 +70856,12 @@ var require_errors4 = __commonJS({
       }
       if (/[^ ]/.test(lineStr)) {
         let count = 1;
-        const end = error.linePos[1];
+        const end = error2.linePos[1];
         if (end && end.line === line && end.col > col) {
           count = Math.max(1, Math.min(end.col - col, 80 - ci));
         }
         const pointer = " ".repeat(ci) + "^".repeat(count);
-        error.message += `:
+        error2.message += `:
 
 ${lineStr}
 ${pointer}
@@ -71627,7 +71627,7 @@ var require_resolve_block_scalar = __commonJS({
       const mode = source[0];
       let indent = 0;
       let chomp = "";
-      let error = -1;
+      let error2 = -1;
       for (let i = 1; i < source.length; ++i) {
         const ch = source[i];
         if (!chomp && (ch === "-" || ch === "+"))
@@ -71636,12 +71636,12 @@ var require_resolve_block_scalar = __commonJS({
           const n = Number(ch);
           if (!indent && n)
             indent = n;
-          else if (error === -1)
-            error = offset + i;
+          else if (error2 === -1)
+            error2 = offset + i;
         }
       }
-      if (error !== -1)
-        onError(error, "UNEXPECTED_TOKEN", `Block scalar header includes extra characters: ${source}`);
+      if (error2 !== -1)
+        onError(error2, "UNEXPECTED_TOKEN", `Block scalar header includes extra characters: ${source}`);
       let hasSpace = false;
       let comment = "";
       let length = source.length;
@@ -71910,8 +71910,8 @@ var require_compose_scalar = __commonJS({
       try {
         const res = tag.resolve(value, (msg) => onError(tagToken ?? token, "TAG_RESOLVE_FAILED", msg), ctx.options);
         scalar = identity.isScalar(res) ? res : new Scalar.Scalar(res);
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
+      } catch (error2) {
+        const msg = error2 instanceof Error ? error2.message : String(error2);
         onError(tagToken ?? token, "TAG_RESOLVE_FAILED", msg);
         scalar = new Scalar.Scalar(value);
       }
@@ -72285,11 +72285,11 @@ ${cb}` : comment;
             break;
           case "error": {
             const msg = token.source ? `${token.message}: ${JSON.stringify(token.source)}` : token.message;
-            const error = new errors.YAMLParseError(getErrorPos(token), "UNEXPECTED_TOKEN", msg);
+            const error2 = new errors.YAMLParseError(getErrorPos(token), "UNEXPECTED_TOKEN", msg);
             if (this.atDirectives || !this.doc)
-              this.errors.push(error);
+              this.errors.push(error2);
             else
-              this.doc.errors.push(error);
+              this.doc.errors.push(error2);
             break;
           }
           case "doc-end": {
@@ -73568,8 +73568,8 @@ var require_parser = __commonJS({
       peek(n) {
         return this.stack[this.stack.length - n];
       }
-      *pop(error) {
-        const token = error ?? this.stack.pop();
+      *pop(error2) {
+        const token = error2 ?? this.stack.pop();
         if (!token) {
           const message = "Tried to pop an empty stack";
           yield { type: "error", offset: this.offset, source: "", message };
@@ -74343,7 +74343,7 @@ var require_dist = __commonJS({
 var import_fs3 = __toESM(require("fs"));
 var import_path2 = __toESM(require("path"));
 var import_process = require("process");
-var import_core2 = __toESM(require_core());
+var import_core3 = __toESM(require_core());
 var import_tool_cache = __toESM(require_tool_cache());
 var import_jszip = __toESM(require_lib4());
 
@@ -75127,14 +75127,14 @@ async function downloadDatabase(repoId, repoName, language, pat) {
       authHeader,
       "application/zip"
     );
-  } catch (error) {
+  } catch (error2) {
     console.log("Error while downloading database");
-    if (error instanceof HTTPError && error.httpStatusCode === 404 && error.httpMessage.includes("No database available for")) {
+    if (error2 instanceof HTTPError && error2.httpStatusCode === 404 && error2.httpMessage.includes("No database available for")) {
       throw new Error(
         `Language mismatch: The query targets ${language}, but the repository "${repoName}" has no CodeQL database available for that language.`
       );
     } else {
-      throw error;
+      throw error2;
     }
   }
 }
@@ -75298,8 +75298,8 @@ function getDatabaseMetadata(databasePath) {
     return parseYamlFromFile(
       import_path.default.join(databasePath, "codeql-database.yml")
     );
-  } catch (error) {
-    console.log(`Unable to read codeql-database.yml: ${error}`);
+  } catch (error2) {
+    console.log(`Unable to read codeql-database.yml: ${error2}`);
     return {};
   }
 }
@@ -75349,6 +75349,7 @@ function getQueryPackName(queryPackPath) {
 }
 
 // src/codeql-cli.ts
+var import_core2 = __toESM(require_core());
 var import_exec = __toESM(require_exec());
 var BaseCodeqlCli = class {
   constructor(codeqlPath) {
@@ -75366,17 +75367,17 @@ var BaseCodeqlCli = class {
 // src/query.ts
 async function run() {
   const controllerRepoId = getControllerRepoId();
-  const queryPackUrl = (0, import_core2.getInput)("query_pack_url", { required: true });
-  const language = (0, import_core2.getInput)("language", { required: true });
+  const queryPackUrl = (0, import_core3.getInput)("query_pack_url", { required: true });
+  const language = (0, import_core3.getInput)("language", { required: true });
   const repos = getRepos();
-  const codeql = (0, import_core2.getInput)("codeql", { required: true });
+  const codeql = (0, import_core3.getInput)("codeql", { required: true });
   const variantAnalysisId = getVariantAnalysisId();
   for (const repo of repos) {
     if (repo.downloadUrl) {
-      (0, import_core2.setSecret)(repo.downloadUrl);
+      (0, import_core3.setSecret)(repo.downloadUrl);
     }
     if (repo.pat) {
-      (0, import_core2.setSecret)(repo.pat);
+      (0, import_core3.setSecret)(repo.pat);
     }
   }
   const curDir = (0, import_process.cwd)();
@@ -75385,15 +75386,15 @@ async function run() {
     console.log("Getting query pack");
     const queryPackArchive = await download(queryPackUrl, "query_pack.tar.gz");
     queryPackPath = await (0, import_tool_cache.extractTar)(queryPackArchive);
-  } catch (error) {
-    console.error(error);
-    const errorMessage = error instanceof Error ? error.message : `${error}`;
-    if (error instanceof import_tool_cache.HTTPError && error.httpStatusCode === 403) {
-      (0, import_core2.setFailed)(
+  } catch (error2) {
+    console.error(error2);
+    const errorMessage = error2 instanceof Error ? error2.message : `${error2}`;
+    if (error2 instanceof import_tool_cache.HTTPError && error2.httpStatusCode === 403) {
+      (0, import_core3.setFailed)(
         `${errorMessage}. The query pack is only available for 24 hours. To retry, create a new variant analysis.`
       );
     } else {
-      (0, import_core2.setFailed)(errorMessage);
+      (0, import_core3.setFailed)(errorMessage);
     }
     for (const repo of repos) {
       await setVariantAnalysisFailed(
@@ -75441,15 +75442,15 @@ async function run() {
         runQueryResult.resultCount,
         runQueryResult.databaseSHA || "HEAD"
       );
-    } catch (error) {
-      console.error(error);
-      const errorMessage = error instanceof Error ? error.message : `${error}`;
-      if (error instanceof import_tool_cache.HTTPError && error.httpStatusCode === 403) {
-        (0, import_core2.setFailed)(
+    } catch (error2) {
+      console.error(error2);
+      const errorMessage = error2 instanceof Error ? error2.message : `${error2}`;
+      if (error2 instanceof import_tool_cache.HTTPError && error2.httpStatusCode === 403) {
+        (0, import_core3.setFailed)(
           `${errorMessage}. Database downloads are only available for 24 hours. To retry, create a new variant analysis.`
         );
       } else {
-        (0, import_core2.setFailed)(errorMessage);
+        (0, import_core3.setFailed)(errorMessage);
       }
       await setVariantAnalysisFailed(
         controllerRepoId,

--- a/src/codeql-cli.test.ts
+++ b/src/codeql-cli.test.ts
@@ -1,0 +1,76 @@
+import fs from "fs";
+import { tmpdir } from "os";
+import path from "path";
+
+import { rmRF } from "@actions/io";
+import anyTest, { TestFn } from "ava";
+
+import { getQueryPackInfo } from "./codeql";
+import { CodeqlCli, CodeqlCliServer } from "./codeql-cli";
+
+const test = anyTest as TestFn<{
+  tmpDir: string;
+  cli: CodeqlCli;
+}>;
+
+test.before((t) => {
+  t.context.cli = new CodeqlCliServer(process.env.CODEQL_BIN_PATH || "codeql");
+});
+
+test.after((t) => {
+  if (t.context.cli && t.context.cli instanceof CodeqlCliServer) {
+    t.context.cli.shutdown();
+  }
+});
+
+test.beforeEach((t) => {
+  // Use a different temporary directory that tests can use
+  t.context.tmpDir = path.resolve(fs.mkdtempSync(path.join(tmpdir(), "tmp-")));
+});
+
+test.afterEach(async (t) => {
+  if (t.context?.tmpDir !== undefined) {
+    await rmRF(t.context.tmpDir);
+  }
+});
+
+test("create and bundle a database", async (t) => {
+  const projectDir = path.join(t.context.tmpDir, "project");
+  const dbDir = path.join(t.context.tmpDir, "db");
+  fs.mkdirSync(projectDir);
+  const testFile = path.join(projectDir, "test.js");
+  fs.writeFileSync(testFile, "const x = 1;");
+
+  await t.context.cli.run([
+    "database",
+    "create",
+    "--language=javascript",
+    `--source-root=${projectDir}`,
+    dbDir,
+  ]);
+
+  const dbZip = path.join(t.context.tmpDir, "database.zip");
+  await t.context.cli.run(["database", "bundle", `--output=${dbZip}`, dbDir]);
+
+  t.true(fs.statSync(dbZip).isFile());
+});
+
+test("getting query pack info", async (t) => {
+  const queryPackInfo = await getQueryPackInfo(
+    t.context.cli,
+    "testdata/test_pack",
+  );
+
+  const queries = {};
+  queries[path.resolve("testdata/test_pack/x/query.ql")] = {
+    name: "Test query",
+    description: "Test query description",
+    kind: "table",
+    id: "test/query/id",
+  };
+  t.deepEqual(queryPackInfo, {
+    path: path.resolve("testdata/test_pack"),
+    name: "codeql/queries",
+    queries,
+  });
+});

--- a/src/codeql-cli.ts
+++ b/src/codeql-cli.ts
@@ -1,3 +1,7 @@
+import { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { EOL } from "node:os";
+
+import { debug, error } from "@actions/core";
 import { getExecOutput } from "@actions/exec";
 
 export interface CodeqlCliOutput {
@@ -20,5 +24,205 @@ export class BaseCodeqlCli implements CodeqlCli {
     );
 
     return { stdout, stderr, exitCode };
+  }
+}
+
+export class CodeqlCliServer implements CodeqlCli {
+  /**
+   * The process for the cli server, or undefined if one doesn't exist yet
+   */
+  private process?: ChildProcessWithoutNullStreams;
+  /**
+   * Queue of future commands
+   */
+  private readonly commandQueue: Array<() => void> = [];
+  /**
+   * Whether a command is running
+   */
+  private commandInProcess: boolean = false;
+  /**
+   * A buffer with a single null byte.
+   */
+  private readonly nullBuffer: Buffer = Buffer.alloc(1);
+
+  constructor(private readonly codeqlPath: string) {}
+
+  run(args: string[]): Promise<CodeqlCliOutput> {
+    return new Promise((resolve, reject) => {
+      const callback = (): void => {
+        try {
+          // eslint-disable-next-line github/no-then -- we might not run immediately
+          this.runCommandImmediately(args).then(resolve, reject);
+        } catch (err) {
+          reject(err);
+        }
+      };
+      // If the server is not running a command, then run the given command immediately,
+      // otherwise add to the queue
+      if (this.commandInProcess) {
+        this.commandQueue.push(callback);
+      } else {
+        callback();
+      }
+    });
+  }
+
+  /**
+   * Launch the cli server
+   */
+  private launchProcess(): ChildProcessWithoutNullStreams {
+    const args = ["execute", "cli-server"];
+
+    // Start the server process.
+    const argsString = args.join(" ");
+    void debug(`Starting using CodeQL CLI: ${this.codeqlPath} ${argsString}`);
+    const child = spawn(this.codeqlPath, args);
+    if (!child || !child.pid) {
+      throw new Error(
+        `Failed to start using command ${this.codeqlPath} ${argsString}.`,
+      );
+    }
+
+    let lastStdout: string | Buffer | undefined = undefined;
+    child.stdout.on("data", (data: string | Buffer) => {
+      lastStdout = data;
+    });
+    // Set up event listeners.
+    child.on("close", (code, signal) => {
+      if (code !== null) {
+        debug(`Child process exited with code ${code}`);
+      }
+      if (signal) {
+        debug(`Child process exited due to receipt of signal ${signal}`);
+      }
+      // If the process exited abnormally, log the last stdout message,
+      // It may be from the jvm.
+      if (code !== 0 && lastStdout !== undefined) {
+        debug(`Last stdout was "${lastStdout.toString()}"`);
+      }
+    });
+
+    return child;
+  }
+
+  private async runCommandImmediately(
+    args: string[],
+  ): Promise<CodeqlCliOutput> {
+    const stderrBuffers: Buffer[] = [];
+    if (this.commandInProcess) {
+      throw new Error(
+        "runCommandImmediately called while command was in process",
+      );
+    }
+    this.commandInProcess = true;
+    try {
+      // Launch the process if it doesn't exist
+      if (!this.process) {
+        this.process = this.launchProcess();
+      }
+      const process = this.process;
+      // The array of fragments of stdout
+      const stdoutBuffers: Buffer[] = [];
+
+      void debug(`Running using CodeQL CLI: ${args.join(" ")}`);
+      try {
+        await new Promise<void>((resolve, reject) => {
+          // Start listening to stdout
+          process.stdout.addListener("data", (newData: Buffer) => {
+            stdoutBuffers.push(newData);
+            // If the buffer ends in '0' then exit.
+            // We don't have to check the middle as no output will be written after the null until
+            // the next command starts
+            if (
+              newData.length > 0 &&
+              newData.readUInt8(newData.length - 1) === 0
+            ) {
+              resolve();
+            }
+          });
+          // Listen to stderr
+          process.stderr.addListener("data", (newData: Buffer) => {
+            stderrBuffers.push(newData);
+          });
+          // Listen for process exit.
+          process.addListener("close", (code) =>
+            reject(
+              new Error(
+                `The process ${this.codeqlPath} ${args.join(" ")} exited with code ${code}`,
+              ),
+            ),
+          );
+          // Write the command followed by a null terminator.
+          process.stdin.write(JSON.stringify(args), "utf8");
+          process.stdin.write(this.nullBuffer);
+        });
+
+        void debug("CLI command succeeded.");
+
+        const stdoutBuffer = Buffer.concat(stdoutBuffers);
+
+        return {
+          exitCode: 0,
+          stdout: stdoutBuffer.toString("utf8", 0, stdoutBuffer.length - 1),
+          stderr: Buffer.concat(stderrBuffers).toString("utf8"),
+        };
+      } catch (err) {
+        // Kill the process if it isn't already dead.
+        this.killProcessIfRunning();
+
+        if (stderrBuffers.length > 0) {
+          error(
+            `Failed to run ${args.join(" ")}:${EOL} ${Buffer.concat(stderrBuffers).toString("utf8")}`,
+          );
+        }
+
+        throw err;
+      } finally {
+        debug(Buffer.concat(stderrBuffers).toString("utf8"));
+        // Remove the listeners we set up.
+        process.stdout.removeAllListeners("data");
+        process.stderr.removeAllListeners("data");
+        process.removeAllListeners("close");
+      }
+    } finally {
+      this.commandInProcess = false;
+      // start running the next command immediately
+      this.runNext();
+    }
+  }
+
+  /**
+   * Run the next command in the queue
+   */
+  private runNext(): void {
+    const callback = this.commandQueue.shift();
+    if (callback) {
+      callback();
+    }
+  }
+
+  private killProcessIfRunning(): void {
+    if (this.process) {
+      // Tell the Java CLI server process to shut down.
+      debug("Sending shutdown request");
+      try {
+        this.process.stdin.write(JSON.stringify(["shutdown"]), "utf8");
+        this.process.stdin.write(this.nullBuffer);
+        debug("Sent shutdown request");
+      } catch (e: unknown) {
+        // We are probably fine here, the process has already closed stdin.
+        debug(
+          `Shutdown request failed: process stdin may have already closed. The error was ${e}`,
+        );
+        debug("Stopping the process anyway.");
+      }
+      // Close the stdin and stdout streams.
+      // This is important on Windows where the child process may not die cleanly.
+      this.process.stdin.end();
+      this.process.kill();
+      this.process.stdout.destroy();
+      this.process.stderr.destroy();
+      this.process = undefined;
+    }
   }
 }

--- a/src/codeql-cli.ts
+++ b/src/codeql-cli.ts
@@ -1,0 +1,24 @@
+import { getExecOutput } from "@actions/exec";
+
+export interface CodeqlCliOutput {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface CodeqlCli {
+  run(args: string[]): Promise<CodeqlCliOutput>;
+}
+
+export class BaseCodeqlCli implements CodeqlCli {
+  constructor(private readonly codeqlPath: string) {}
+
+  async run(args: string[]): Promise<CodeqlCliOutput> {
+    const { stdout, stderr, exitCode } = await getExecOutput(
+      this.codeqlPath,
+      args,
+    );
+
+    return { stdout, stderr, exitCode };
+  }
+}

--- a/src/codeql-cli.ts
+++ b/src/codeql-cli.ts
@@ -67,6 +67,10 @@ export class CodeqlCliServer implements CodeqlCli {
     });
   }
 
+  shutdown() {
+    this.killProcessIfRunning();
+  }
+
   /**
    * Launch the cli server
    */

--- a/src/codeql-cli.ts
+++ b/src/codeql-cli.ts
@@ -5,7 +5,7 @@ import { Writable } from "node:stream";
 import { debug, error } from "@actions/core";
 import { getExecOutput } from "@actions/exec";
 
-export interface CodeqlCliOutput {
+interface CodeqlCliOutput {
   exitCode: number;
   stdout: string;
   stderr: string;

--- a/src/query.ts
+++ b/src/query.ts
@@ -13,6 +13,7 @@ import {
   runQuery,
   RunQueryResult,
 } from "./codeql";
+import { BaseCodeqlCli } from "./codeql-cli";
 import { download } from "./download";
 import {
   getPolicyForRepoArtifact,
@@ -74,7 +75,9 @@ async function run(): Promise<void> {
     return;
   }
 
-  const queryPackInfo = await getQueryPackInfo(codeql, queryPackPath);
+  const codeqlCli = new BaseCodeqlCli(codeql);
+
+  const queryPackInfo = await getQueryPackInfo(codeqlCli, queryPackPath);
 
   for (const repo of repos) {
     // Create a new directory to contain all files created during analysis of this repo.
@@ -94,7 +97,7 @@ async function run(): Promise<void> {
 
       console.log("Running query");
       const runQueryResult = await runQuery(
-        codeql,
+        codeqlCli,
         dbZipPath,
         repo.nwo,
         queryPackInfo,

--- a/src/query.ts
+++ b/src/query.ts
@@ -13,7 +13,7 @@ import {
   runQuery,
   RunQueryResult,
 } from "./codeql";
-import { BaseCodeqlCli } from "./codeql-cli";
+import { BaseCodeqlCli, CodeqlCliServer } from "./codeql-cli";
 import { download } from "./download";
 import {
   getPolicyForRepoArtifact,
@@ -75,7 +75,9 @@ async function run(): Promise<void> {
     return;
   }
 
-  const codeqlCli = new BaseCodeqlCli(codeql);
+  const codeqlCli = process.env.CODEQL_VARIANT_ANALYSIS_ACTION_USE_CLI_SERVER
+    ? new CodeqlCliServer(codeql)
+    : new BaseCodeqlCli(codeql);
 
   const queryPackInfo = await getQueryPackInfo(codeqlCli, queryPackPath);
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -90,11 +90,12 @@ async function run(): Promise<void> {
       );
 
       const dbZip = await getDatabase(repo, language);
+      const dbZipPath = path.resolve(dbZip);
 
       console.log("Running query");
       const runQueryResult = await runQuery(
         codeql,
-        dbZip,
+        dbZipPath,
         repo.nwo,
         queryPackInfo,
       );

--- a/variant-analysis-workflow.yml
+++ b/variant-analysis-workflow.yml
@@ -5,6 +5,7 @@ run-name: ${{ github.event.inputs.workflow_name }}
 env:
   CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: true
   CODEQL_VARIANT_ANALYSIS_ACTION_WAIT_ON_RATE_LIMIT: ${{ (vars.MRVA_WAIT_ON_RATE_LIMIT && true) || '' }}
+  CODEQL_VARIANT_ANALYSIS_ACTION_USE_CLI_SERVER: ${{ (vars.MRVA_USE_CLI_SERVER && true) || '' }}
 
 on: dynamic
 


### PR DESCRIPTION
This PR adds the ability to use the CodeQL CLI server for running commands. This results in better performance of individual command invocations since there's less JVM overhead. On a test I ran, the overhead (defined as time not spent running `codeql database run-queries`) went down from 20% to 3-5%.

This is currently guarded by the `MRVA_USE_CLI_SERVER` repo Actions variable. We can probably remove this in a follow-up PR once this has been sufficiently tested.