### PR TITLE
Add support for alert and path-alert aliases

### DIFF
--- a/dist/query.js
+++ b/dist/query.js
@@ -76705,9 +76705,15 @@ function queryPackSupportsSarif(queriesResultInfo) {
 }
 function getSarifOutputType(queryMetadata, compatibleQueryKinds) {
   const queryKind = queryMetadata.kind;
-  if (queryKind === "path-problem" && compatibleQueryKinds.includes("PathProblem")) {
+  if (
+    // path-alert is an alias of path-problem
+    (queryKind === "path-problem" || queryKind === "path-alert") && compatibleQueryKinds.includes("PathProblem")
+  ) {
     return "path-problem";
-  } else if (queryKind === "problem" && compatibleQueryKinds.includes("Problem")) {
+  } else if (
+    // alert is an alias of problem
+    (queryKind === "problem" || queryKind === "alert") && compatibleQueryKinds.includes("Problem")
+  ) {
     return "problem";
   } else {
     return void 0;

--- a/src/codeql.test.ts
+++ b/src/codeql.test.ts
@@ -319,6 +319,36 @@ test("getting the SARIF output type when the `@kind` metadata is compatible with
   t.is(getSarifOutputType(queryMetadata, compatibleQueryKinds), "problem");
 });
 
+test("getting the SARIF output type when the `@kind` metadata is an alert alias", (t) => {
+  const queryMetadata: QueryMetadata = {
+    kind: "alert",
+  };
+
+  const compatibleQueryKinds = [
+    "Problem",
+    "PathProblem",
+    "Table",
+    "Diagnostic",
+  ];
+
+  t.is(getSarifOutputType(queryMetadata, compatibleQueryKinds), "problem");
+});
+
+test("getting the SARIF output type when the `@kind` metadata is a path-alert alias", (t) => {
+  const queryMetadata: QueryMetadata = {
+    kind: "path-alert",
+  };
+
+  const compatibleQueryKinds = [
+    "Problem",
+    "PathProblem",
+    "Table",
+    "Diagnostic",
+  ];
+
+  t.is(getSarifOutputType(queryMetadata, compatibleQueryKinds), "path-problem");
+});
+
 test("uses result count from #select result set if it exists", (t) => {
   const bqrsInfo: BQRSInfo = {
     resultSets: [{ name: "#select", rows: 3 }],

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -354,12 +354,14 @@ export function getSarifOutputType(
 ): SarifOutputType | undefined {
   const queryKind = queryMetadata.kind;
   if (
-    queryKind === "path-problem" &&
+    // path-alert is an alias of path-problem
+    (queryKind === "path-problem" || queryKind === "path-alert") &&
     compatibleQueryKinds.includes("PathProblem")
   ) {
     return "path-problem";
   } else if (
-    queryKind === "problem" &&
+    // alert is an alias of problem
+    (queryKind === "problem" || queryKind === "alert") &&
     compatibleQueryKinds.includes("Problem")
   ) {
     return "problem";


### PR DESCRIPTION
This adds support for the `alert` and `path-alert` aliases to treat them as `problem` and `path-problem`, respectively.