### PR TITLE
Add support for GHEC-DR

### DIFF
--- a/dist/query.js
+++ b/dist/query.js
@@ -77806,14 +77806,15 @@ async function generateSarif(codeql, nwo, databasePath, queryPackPath, databaseS
 function injectVersionControlInfo(sarif, nwo, databaseSHA) {
   for (const run2 of sarif.runs) {
     run2.versionControlProvenance = run2.versionControlProvenance || [];
+    const repositoryUri = `${process.env.GITHUB_SERVER_URL || "https://github.com"}/${nwo}`;
     if (databaseSHA) {
       run2.versionControlProvenance.push({
-        repositoryUri: `https://github.com/${nwo}`,
+        repositoryUri,
         revisionId: databaseSHA
       });
     } else {
       run2.versionControlProvenance.push({
-        repositoryUri: `https://github.com/${nwo}`
+        repositoryUri
       });
     }
   }

--- a/dist/query.js
+++ b/dist/query.js
@@ -77661,7 +77661,7 @@ async function downloadDatabase(repoId, repoName, language, pat) {
   }
   try {
     return await download(
-      `https://api.github.com/repos/${repoName}/code-scanning/codeql/databases/${language}`,
+      `${process.env.GITHUB_API_URL || "https://api.github.com"}/repos/${repoName}/code-scanning/codeql/databases/${language}`,
       `${repoId}.zip`,
       authHeader,
       "application/zip"

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -158,7 +158,7 @@ export async function downloadDatabase(
 
   try {
     return await download(
-      `https://api.github.com/repos/${repoName}/code-scanning/codeql/databases/${language}`,
+      `${process.env.GITHUB_API_URL || "https://api.github.com"}/repos/${repoName}/code-scanning/codeql/databases/${language}`,
       `${repoId}.zip`,
       authHeader,
       "application/zip",

--- a/src/codeql.ts
+++ b/src/codeql.ts
@@ -409,14 +409,15 @@ export function injectVersionControlInfo(
 ): void {
   for (const run of sarif.runs) {
     run.versionControlProvenance = run.versionControlProvenance || [];
+    const repositoryUri = `${process.env.GITHUB_SERVER_URL || "https://github.com"}/${nwo}`;
     if (databaseSHA) {
       run.versionControlProvenance.push({
-        repositoryUri: `https://github.com/${nwo}`,
+        repositoryUri,
         revisionId: databaseSHA,
       });
     } else {
       run.versionControlProvenance.push({
-        repositoryUri: `https://github.com/${nwo}`,
+        repositoryUri,
       });
     }
   }


### PR DESCRIPTION
This adds support for GHEC-DR. It replaces hardcoded `github.com` URLs by [the environment variables available in Actions](https://docs.github.com/en/actions/learn-github-actions/variables) with a fallback to the current value. This matches [what `@octokit/action` does](https://github.com/octokit/action.js/blob/aee7aaedceedcf7cd64db65cc9aff03bf95f3f25/src/index.ts#L56C10-L56C67). Since `@octokit/action` already does this, we don't need to make any changes to Octokit constructors and this is handled automatically.