### PR TITLE
Upgrade eslint-plugin-escompat to v3.11.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5734,11 +5734,13 @@
       }
     },
     "node_modules/eslint-plugin-escompat": {
-      "version": "3.4.0",
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-escompat/-/eslint-plugin-escompat-3.11.3.tgz",
+      "integrity": "sha512-Gz/eTJzl7fK9SPBkvB3t+xc1iribxRc5Fgu6Z7206b5q1d7kG0t8Drtin8MRY4UgGBg8Zu1HG6RGzR35LCUpLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.21.0"
+        "browserslist": "^4.23.1"
       },
       "peerDependencies": {
         "eslint": ">=5.14.1"


### PR DESCRIPTION
I ran `npm upgrade eslint-plugin-escompat` to upgrade this dependency which should unblock https://github.com/github/codeql-variant-analysis-action/pull/1091.