### PR TITLE
Downgrade @types/node to v20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@octokit/types": "^13.6.1",
         "@types/archiver": "^6.0.3",
         "@types/jest": "^29.5.14",
-        "@types/node": "^22.7.7",
+        "@types/node": "^20.17.6",
         "@types/semver": "^7.5.8",
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.14.0",
@@ -3591,10 +3591,11 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.7.tgz",
-      "integrity": "sha512-SRxCrrg9CL/y54aiMCG3edPKdprgMVGDXjA3gB8UmmBW5TcXzRUYAh8EWzTnSJFAd1rgImPELza+A3bJ+qxz8Q==",
+      "version": "20.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.6.tgz",
+      "integrity": "sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@octokit/types": "^13.6.1",
     "@types/archiver": "^6.0.3",
     "@types/jest": "^29.5.14",
-    "@types/node": "^22.7.7",
+    "@types/node": "^20.17.6",
     "@types/semver": "^7.5.8",
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.14.0",


### PR DESCRIPTION
The action is [still running](https://github.com/github/codeql-variant-analysis-action/blob/0fc08f096774edf4331e9e13aba0bb3d280898fa/query/action.yml#L34) on Node 20, so we should be using `@types/node` v20, not v22.