### PR TITLE
Pin action SHAs across all workflows and do not mark PR as draft in `rebuild` workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           config-file: ./.github/codeql/codeql-config.yml
           languages: "javascript"
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,8 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24.x"
           cache: "npm"
@@ -25,13 +26,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24.x"
           cache: "npm"
+
       - name: Install dependencies
         run: npm ci
+
       - name: Check generated JavaScript
         run: .github/workflows/script/check-js.sh
 
@@ -39,8 +43,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24.x"
           cache: "npm"
@@ -53,8 +58,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24.x"
           cache: "npm"
@@ -71,18 +77,19 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24.x"
           cache: "npm"
+
       - name: Install dependencies
         run: npm ci
 
       - name: Initialize CodeQL
         id: init
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: javascript
 

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           ref: ${{ env.HEAD_REF }}

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -131,5 +131,5 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           echo "Pushed a commit to rebuild the Action." \
-            "Please mark the PR as ready for review to trigger PR checks." |
+            "Please approve running the PR checks." |
             gh pr comment --body-file - --repo github/codeql-variant-analysis-action "$PR_NUMBER"

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          cache: 'npm'
+          cache: "npm"
 
       - name: Remove label
         if: github.event_name == 'pull_request'
@@ -133,4 +133,3 @@ jobs:
           echo "Pushed a commit to rebuild the Action." \
             "Please mark the PR as ready for review to trigger PR checks." |
             gh pr comment --body-file - --repo github/codeql-variant-analysis-action "$PR_NUMBER"
-          gh pr ready --undo --repo github/codeql-variant-analysis-action "$PR_NUMBER"


### PR DESCRIPTION
Marking the PR as "draft" in the `rebuild` workflow is not necessary, because we can now use the "Approve workflow runs" feature in the UI to approve workflow runs for a CI-generated commit.