### PR TITLE
Dependabot: Change `npm` groupings to prioritise grouping minor/patch version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,21 +29,18 @@ updates:
     labels:
       - "Rebuild"
     groups:
-      actions:
-        patterns:
-          - "@actions/*"
-      octokit:
-        patterns:
-          - "@octokit/*"
-        update-types:
-          - "minor"
-          - "patch"
-      typescript-eslint:
-        patterns:
-          - "@typescript-eslint/*"
       npm-minor:
         patterns:
           - "*"
         update-types:
           - "minor"
           - "patch"
+      actions:
+        patterns:
+          - "@actions/*"
+      octokit:
+        patterns:
+          - "@octokit/*"
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"


### PR DESCRIPTION
Follow-up change to #1413 since we don't need a separate group for minor/patch-level `octokit` updates. One group for all minor/patch-level updates is enough.