### PR TITLE
Align @eslint/js with ESLint 9 and pin the pair in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,12 @@ updates:
         - "@actions/*"
     labels:
       - "Rebuild"
+    # ESLint 10 is blocked only by eslint-plugin-github's transitive
+    # eslint-plugin-import and eslint-plugin-jsx-a11y peers; this repo itself
+    # lints clean on ESLint 10. Lift both ignores once those plugins support it.
     ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@eslint/js"
         update-types: ["version-update:semver-major"]
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,14 @@ updates:
     labels:
       - "Rebuild"
     groups:
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/js"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
       actions:
         patterns:
           - "@actions/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,9 @@ updates:
         - "@actions/*"
     labels:
       - "Rebuild"
+    ignore:
+      - dependency-name: "@eslint/js"
+        update-types: ["version-update:semver-major"]
     groups:
       eslint:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,8 +44,6 @@ updates:
           - "@eslint/js"
         update-types:
           - "major"
-          - "minor"
-          - "patch"
       actions:
         patterns:
           - "@actions/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,8 +29,9 @@ updates:
     labels:
       - "Rebuild"
     # ESLint 10 is blocked only by eslint-plugin-github's transitive
-    # eslint-plugin-import and eslint-plugin-jsx-a11y peers; this repo itself
-    # lints clean on ESLint 10. Lift both ignores once those plugins support it.
+    # eslint-plugin-import and eslint-plugin-jsx-a11y peers, with no upstream
+    # support currently signaled. This repo itself lints clean on ESLint 10;
+    # lift both ignores together once those plugins support it.
     ignore:
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@babel/preset-react": "^7.29.7",
         "@babel/preset-typescript": "^7.29.7",
         "@eslint/eslintrc": "^3.3.6",
-        "@eslint/js": "^10.0.1",
+        "@eslint/js": "^9.39.5",
         "@octokit/types": "^16.0.0",
         "@types/archiver": "^8.0.0",
         "@types/node": "^26.1.2",
@@ -2541,24 +2541,16 @@
       "license": "MIT"
     },
     "node_modules/@eslint/js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
-      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "eslint": "^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -6032,19 +6024,6 @@
         "eslint": "^8 || ^9 || ^10"
       }
     },
-    "node_modules/eslint-plugin-github/node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      }
-    },
     "node_modules/eslint-plugin-github/node_modules/globals": {
       "version": "17.7.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
@@ -6237,19 +6216,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
-      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/eslint/node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/preset-react": "^7.29.7",
     "@babel/preset-typescript": "^7.29.7",
     "@eslint/eslintrc": "^3.3.6",
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.5",
     "@octokit/types": "^16.0.0",
     "@types/archiver": "^8.0.0",
     "@types/node": "^26.1.2",


### PR DESCRIPTION
## Summary

- change the direct `@eslint/js` range from `^10.0.1` to the latest 9.x, `^9.39.5`, while keeping `eslint` at `^9.39.5`
- regenerate the lockfile into a peer-clean graph with one deduplicated `@eslint/js@9.39.5`
- declaratively ignore major updates for both `eslint` and `@eslint/js`
- group major `eslint` and `@eslint/js` updates for when both packages are unpinned; minor and patch updates remain in the existing `npm-minor` group

This supersedes closed [#1456](https://github.com/github/codeql-variant-analysis-action/pull/1456) and is based directly on `main` without reusing that branch or history.

## Context

The `@eslint/js@^10.0.1` / `eslint@^9.39.5` peer mismatch made clean lockfile regeneration impossible, while the frozen lockfile used by `npm ci` kept passing and hid the mismatch for roughly six weeks. [#1372](https://github.com/github/codeql-variant-analysis-action/pull/1372) merged `@eslint/js` 10.0.1 on June 22, 2026. [#1424](https://github.com/github/codeql-variant-analysis-action/pull/1424), which proposed ESLint 10.5.0, closed on June 23 after `@dependabot ignore this major version`, leaving only half of the pair upgraded.

ESLint 10 is deferred purely because `eslint-plugin-github` transitively depends on `eslint-plugin-import` and `eslint-plugin-jsx-a11y`, whose peer ranges exclude it. `eslint-plugin-import@2.32.0` allows `^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9`; `eslint-plugin-jsx-a11y@6.10.2` allows `^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9`. npm can install ESLint 10 only by overriding those peers, and `npm ls` marks `eslint@10.8.0` invalid.

This is not migration debt in this repository: the ESLint 10.8.0 investigation required no source or lint-configuration changes, produced zero lint violations, and passed all 44 tests. However, `npm ci --dry-run --strict-peer-deps` fails ERESOLVE immediately on `eslint-plugin-import`'s range. The ESLint 10 route therefore breaks outright for strict-peer-deps users and remains exposed to any future npm default change; alignment is required for an honestly resolvable graph.

Registry inspection found no imminent support signal. `eslint-plugin-import` latest is 2.32.0 and its `next` tag is an obsolete 2.0 beta; `eslint-plugin-jsx-a11y` latest is 6.10.2 with no relevant prerelease; and `eslint-plugin-github` latest is 6.1.2, still depending on `@eslint/js@^9.39.5`, `eslint-plugin-import@^2.31.0`, and `eslint-plugin-jsx-a11y@^6.10.2` with no relevant `next` release.

## Dependabot guard

The `eslint` ignore previously existed only in invisible server-side Dependabot state. Dependabot reports that hidden condition exactly as `[>= 10.a, < 11]`, so it covers ESLint 10.x only, not all future majors.

The declarative semver-major ignores in this PR are intentionally broader and symmetric. Without the declarative `eslint` rule, the 10-only server pin plus an all-major `@eslint/js` pin could eventually allow `eslint@11` while `@eslint/js` remained frozen, mirroring the same half-upgrade trap. Both declarative ignores must be lifted together, and only once `eslint-plugin-import` and `eslint-plugin-jsx-a11y` support ESLint 10 through `eslint-plugin-github`; lifting only one recreates the mismatch.

GitHub's [Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups) states that a dependency matching multiple groups is included in the first group it matches. The specific `eslint` group is therefore declared before the wildcard `npm-minor` group and covers major updates only. Minor and patch updates fall through to `npm-minor`. The ignores hold the line now; the dedicated group will pair eligible major updates once both packages are unpinned.

## Validation

- npm registry confirmed `9.39.5` is the latest `@eslint/js` 9.x
- clean Node 24 `npm install` without force/legacy flags or ERESOLVE peer override warnings
- from-scratch Node 24 `npm ci`
- peer-clean `npm ls` with `@eslint/js@9.39.5` deduplicated across ESLint and `eslint-plugin-github`
- `npm run-script lint`
- `.github/workflows/script/check-js.sh`
- `.github/workflows/script/check-json-schemas.sh`
- `npm run-script find-deadcode`
- all Vitest tests: 44 passed across 5 files