### PR TITLE
Use codeql-ci-app token for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,10 +9,29 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions: {}
     steps:
+      # Token lives ~1h, comfortably longer than this job's timeout, so one mint covers all steps.
+      - name: Generate CI token
+        id: codeql-ci-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          client-id: ${{ vars.CODEQL_CI_APP_CLIENT_ID }}
+          owner: github
+          permission-actions: read # GET actions/runs
+          permission-contents: write # create/read variant analyses
+          private-key: ${{ secrets.CODEQL_CI_APP_PRIVATE_KEY }}
+          repositories: |-
+            codeql-variant-analysis-action
+
       - name: Trigger variant analysis
         id: trigger
         run: |
+          # Deliberately the PR head ref, so the test exercises this PR's action code, not main's.
+          # Non-main refs require the calling actor to hold the mrva_allow_non_default_action_ref
+          # feature flag; codeql-ci-app[bot] is enrolled. If a run fails with "Invalid ref provided",
+          # check that enrolment — do not pin REF to main to go green, as the test would then pass
+          # while no longer testing this PR's code.
           if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
             REF="$GITHUB_HEAD_REF"
           else
@@ -35,7 +54,7 @@ jobs:
           EOF
           echo "input.json: $(cat input.json)"
 
-          RESPONSE=$(curl --no-progress-meter -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" "https://api.github.com/repos/$GITHUB_REPOSITORY/code-scanning/codeql/variant-analyses" -X POST -d @input.json)
+          RESPONSE=$(curl --no-progress-meter -H "Authorization: Bearer ${{ steps.codeql-ci-app-token.outputs.token }}" "https://api.github.com/repos/$GITHUB_REPOSITORY/code-scanning/codeql/variant-analyses" -X POST -d @input.json)
           echo "Response: $RESPONSE"
 
           ID="$(echo "$RESPONSE" | jq '.id')"
@@ -51,7 +70,7 @@ jobs:
       - name: Wait for variant analysis to complete
         run: |
           while true; do
-            RESPONSE=$(curl --no-progress-meter -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" "https://api.github.com/repos/$GITHUB_REPOSITORY/code-scanning/codeql/variant-analyses/${{ steps.trigger.outputs.variant_analysis_id }}")
+            RESPONSE=$(curl --no-progress-meter -H "Authorization: Bearer ${{ steps.codeql-ci-app-token.outputs.token }}" "https://api.github.com/repos/$GITHUB_REPOSITORY/code-scanning/codeql/variant-analyses/${{ steps.trigger.outputs.variant_analysis_id }}")
             STATUS="$(echo "$RESPONSE" | jq '.status' -r)"
             ACTIONS_WORKFLOW_RUN_ID="$(echo "$RESPONSE" | jq '.actions_workflow_run_id' -r)"
             echo "Variant analysis ${{ steps.trigger.outputs.variant_analysis_id }} status: $STATUS"
@@ -68,7 +87,7 @@ jobs:
       - name: Validate variant analysis status
         id: validate
         run: |
-          RESPONSE=$(curl --no-progress-meter -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" "https://api.github.com/repos/$GITHUB_REPOSITORY/code-scanning/codeql/variant-analyses/${{ steps.trigger.outputs.variant_analysis_id }}")
+          RESPONSE=$(curl --no-progress-meter -H "Authorization: Bearer ${{ steps.codeql-ci-app-token.outputs.token }}" "https://api.github.com/repos/$GITHUB_REPOSITORY/code-scanning/codeql/variant-analyses/${{ steps.trigger.outputs.variant_analysis_id }}")
           echo "Response: $RESPONSE"
           echo "Actions workflow URL: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$(echo "$RESPONSE" | jq '.actions_workflow_run_id')"
 
@@ -132,7 +151,7 @@ jobs:
             exit 1
           fi
 
-          ACTIONS_RESPONSE=$(curl --no-progress-meter -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runs/$(echo "$RESPONSE" | jq '.actions_workflow_run_id')")
+          ACTIONS_RESPONSE=$(curl --no-progress-meter -H "Authorization: Bearer ${{ steps.codeql-ci-app-token.outputs.token }}" "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runs/$(echo "$RESPONSE" | jq '.actions_workflow_run_id')")
 
           if [ "$(echo "$ACTIONS_RESPONSE" | jq '.status' -r)" != "completed" ]; then
             echo "Actions workflow status is not completed"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,8 +18,8 @@ jobs:
         with:
           client-id: ${{ vars.CODEQL_CI_APP_CLIENT_ID }}
           owner: github
-          # DIAGNOSTIC: narrowing removed to test whether the analysis-workflow status
-          # callback inherits the creating token's scope. Narrow back once we know.
+          permission-actions: read # GET actions/runs
+          permission-contents: write # create/read variant analyses
           private-key: ${{ secrets.CODEQL_CI_APP_PRIVATE_KEY }}
           repositories: |-
             codeql-variant-analysis-action

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,8 +18,8 @@ jobs:
         with:
           client-id: ${{ vars.CODEQL_CI_APP_CLIENT_ID }}
           owner: github
-          permission-actions: read # GET actions/runs
-          permission-contents: write # create/read variant analyses
+          # DIAGNOSTIC: narrowing removed to test whether the analysis-workflow status
+          # callback inherits the creating token's scope. Narrow back once we know.
           private-key: ${{ secrets.CODEQL_CI_APP_PRIVATE_KEY }}
           repositories: |-
             codeql-variant-analysis-action


### PR DESCRIPTION
## Why

`BOT_TOKEN` is a PAT on the `codeql-remote-query-bot` machine user. It has to be rotated by hand every 90 days, tracked by a recurring Slack reminder. This replaces it with short-lived `codeql-ci-app` installation tokens, which expire on their own and need no rotation.

## Approach

A single `Generate CI token` step at the top of the job mints one installation token, and all four API call sites use it. Minting once is safe because the job's `timeout-minutes: 30` sits comfortably inside the ~1 hour token lifetime.

The token is scoped as narrowly as the calls allow:

* `contents: write` for the variant-analyses endpoints, which run `control_access :write_multi_repository_variant_analysis` / `:read_...` and map to `repo_contents_writer`
* `actions: read` for `GET /actions/runs/{id}`
* `repositories: codeql-variant-analysis-action`, so the token only reaches this repo

Both endpoints already set `allow_integrations: true`, so app tokens are accepted.

## Notes for reviewers

**The token scope and the analysis targets are unrelated.** The JSON payload still lists `docker/compose`, `hashicorp/terraform`, and `github/does-not-exist`. Those are the variant analysis targets and are untouched. They resolve regardless of token scope because public repos are unioned into the accessible set, so scoping the token to one repo does not affect them.

**`permissions: {}` added to the job.** Nothing here uses `GITHUB_TOKEN`: every call passes an explicit `Authorization` header, and `create-github-app-token` authenticates with a private-key JWT, including its post-run token revocation. Worth knowing for later, since a future step that expects `GITHUB_TOKEN` will fail with a 403 that does not obviously point back at this line.

**`action_repo_ref` is unchanged and deliberately not `main`.** The workflow passes the PR head ref so the test exercises the action code from the pull request. Non-default refs are gated on the `mrva_allow_non_default_action_ref` feature flag, and `codeql-ci-app[bot]` is enrolled. I added a comment at the `REF` computation recording this, because a failure here surfaces as `Invalid ref provided. You are only allowed to use main.`, which reads like a workflow bug and invites pinning the ref to `main`. That would make the test pass while no longer testing the PR's code.

**This PR validates itself.** It is a same-repo PR, so secrets are available and the integration test runs with the new auth path against this branch.

## Follow-up, not in this PR

`BOT_TOKEN` still exists as a repository secret. It should stay until the integration test goes green here, so there is a fallback, and then be deleted along with the rotation reminder.

Fork PRs cannot run this workflow, since secrets are unavailable to them. That is pre-existing rather than new: `BOT_TOKEN` was equally a secret. The only difference is that failure now surfaces at the minting step instead of later as a null variant analysis ID.